### PR TITLE
concurrently 'npm dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A happy little skeleton.",
   "main": "index.js",
   "scripts": {
-    "dev":"concurrently \"nodemon --exec npm build\" \"nodemon server\"",//should work after running npm run build once.
+    "dev":"concurrently \"nodemon --exec npm build\" \"nodemon server\"",
     "test": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "test-watch": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register --watch app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "build": "check-node-version --node '>= 6.7.0' && bin/setup && webpack",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A happy little skeleton.",
   "main": "index.js",
   "scripts": {
-    "dev":"concurrently 'npm run start' 'npm run build-watch'",
+    "dev":"concurrently \"nodemon --exec npm build\" \"nodemon server\"",//should work after running npm run build once.
     "test": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "test-watch": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register --watch app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "build": "check-node-version --node '>= 6.7.0' && bin/setup && webpack",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A happy little skeleton.",
   "main": "index.js",
   "scripts": {
+    "dev":"concurrently 'npm run start' 'npm run build-watch'",
     "test": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "test-watch": "check-node-version --node '>= 6.7.0' && bin/setup && mocha --compilers js:babel-register --watch app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "build": "check-node-version --node '>= 6.7.0' && bin/setup && webpack",
@@ -36,6 +37,7 @@
     "chai-enzyme": "^0.5.2",
     "chalk": "^1.1.3",
     "check-node-version": "^1.1.2",
+    "concurrently": "^3.1.0",
     "cookie-session": "^2.0.0-alpha.1",
     "enzyme": "^2.5.1",
     "express": "^4.14.0",


### PR DESCRIPTION
Get rid of the 'build-watch' and 'npm start' . This caused some confusion with the team in our senior project