### PR TITLE
fix(tests): await proper db sync, make stateless, refactor

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -1,19 +1,20 @@
 'use strict'
-const debug = require('debug')('sql')
+const app = require('APP')
+const debugSQL = require('debug')('sql') // DEBUG=sql
+const debugDB = require('debug')(`${app.name}:db`) // DEBUG=your_app_name:db
 const chalk = require('chalk')
 const Sequelize = require('sequelize')
-const app = require('APP')
 
 const name = (process.env.DATABASE_NAME || app.name) +
   (app.isTesting ? '_test' : '')
 
 const url = process.env.DATABASE_URL || `postgres://localhost:5432/${name}`
 
-console.log(chalk.yellow(`Opening database connection to ${url}`));
+debugDB(chalk.yellow(`Opening database connection to ${url}`));
 
 // create the database instance
 const db = module.exports = new Sequelize(url, {
-  logging: debug, // export DEBUG=sql in the environment to get SQL queries
+  logging: debugSQL, // export DEBUG=sql in the environment to get SQL queries
   define: {
     underscored: true,       // use snake_case rather than camelCase column names
     freezeTableName: true,   // don't change table names from the one specified
@@ -27,7 +28,7 @@ require('./models')
 // sync the db, creating it if necessary
 function sync(force=app.isTesting, retries=0, maxRetries=5) {
   return db.sync({force})
-    .then(ok => console.log(`Synced models to db ${url}`))
+    .then(ok => debugDB(`Synced models to db ${url}`))
     .catch(fail => {
       // Don't do this auto-create nonsense in prod, or
       // if we've retried too many times.
@@ -40,7 +41,7 @@ function sync(force=app.isTesting, retries=0, maxRetries=5) {
         return
       }
       // Otherwise, do this autocreate nonsense
-      console.log(`${retries ? `[retry ${retries}]` : ''} Creating database ${name}...`)
+      debugDB(`${retries ? `[retry ${retries}]` : ''} Creating database ${name}...`)
       return new Promise((resolve, reject) =>
         // 'child_process.exec' docs: https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
         require('child_process').exec(`createdb "${name}"`, resolve)

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -5,7 +5,9 @@ const User = require('./user')
 const {expect} = require('chai')
 
 describe('User', () => {
-  before('wait for the db', () => db.didSync)
+
+  before('Await database sync', () => db.didSync)
+  afterEach('Clear the tables', () => db.truncate({ cascade: true }))
 
   describe('authenticate(plaintext: String) ~> Boolean', () => {
     it('resolves true if the password matches', () =>

--- a/package.json
+++ b/package.json
@@ -77,8 +77,7 @@
     "cross-env": "^3.1.4",
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
-    "supertest": "^2.0.1",
-    "supertest-as-promised": "^4.0.1",
+    "supertest": "^3.0.0",
     "volleyball": "^1.4.1",
     "webpack": "^2.2.1",
     "webpack-livereload-plugin": "^0.10.0"

--- a/server/users.test.js
+++ b/server/users.test.js
@@ -1,38 +1,57 @@
-const request = require('supertest-as-promised')
+const request = require('supertest')
 const {expect} = require('chai')
 const db = require('APP/db')
 const User = require('APP/db/models/user')
 const app = require('./start')
 
 describe('/api/users', () => {
-  describe('when not logged in', () => {
-    it('GET /:id fails 401 (Unauthorized)', () =>
-      request(app)
-        .get(`/api/users/1`)
-        .expect(401)
-    )    
 
-    it('POST creates a user', () =>
-      request(app)
-        .post('/api/users')
-        .send({
-          email: 'beth@secrets.org',
-          password: '12345'
-        })
-        .expect(201)
-    )
+  before('Await database sync', () => db.didSync)
+  afterEach('Clear the tables', () => db.truncate({ cascade: true }))
 
-    it('POST redirects to the user it just made', () =>
-      request(app)
-        .post('/api/users')
-        .send({
-          email: 'eve@interloper.com',
-          password: '23456',
-        })
-        .redirects(1)
-        .then(res => expect(res.body).to.contain({
-          email: 'eve@interloper.com'
-        }))        
-    )
+  describe('GET /:id', () => {
+
+    describe('when not logged in', () => {
+
+      it('fails with a 401 (Unauthorized)', () =>
+        request(app)
+          .get(`/api/users/1`)
+          .expect(401)
+      )
+
+    })
+
   })
+
+  describe('POST', () => {
+
+    describe('when not logged in', () => {
+
+      it('creates a user', () =>
+        request(app)
+          .post('/api/users')
+          .send({
+            email: 'beth@secrets.org',
+            password: '12345'
+          })
+          .expect(201)
+      )
+
+      it('redirects to the user it just made', () =>
+        request(app)
+          .post('/api/users')
+          .send({
+            email: 'eve@interloper.com',
+            password: '23456',
+          })
+          .redirects(1)
+          .then(res => expect(res.body).to.contain({
+            email: 'eve@interloper.com'
+          }))
+      )
+
+    })
+
+  })
+
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,10 +136,6 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
-async@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-
 async@^2.1.2:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/async/-/async-2.1.5.tgz#e587c68580994ac67fc56ff86d3ac56bdbe810bc"
@@ -820,7 +816,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.1, bluebird@^3.3.4, bluebird@^3.4.6:
+bluebird@^3.3.4, bluebird@^3.4.6:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
@@ -1752,15 +1748,7 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
-form-data@1.0.0-rc4:
-  version "1.0.0-rc4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.0-rc4.tgz#05ac6bc22227b43e4461f488161554699d4f8b5e"
-  dependencies:
-    async "^1.5.2"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.10"
-
-form-data@~2.1.1:
+form-data@^2.1.1, form-data@~2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.2.tgz#89c3534008b97eada4cbb157d58f6f5df025eae4"
   dependencies:
@@ -1774,9 +1762,9 @@ formatio@1.1.1:
   dependencies:
     samsam "~1.1"
 
-formidable@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.0.17.tgz#ef5491490f9433b705faa77249c99029ae348559"
+formidable@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.1.1.tgz#96b8886f7c3c3508b932d6bd70c4d3a88f35f1a9"
 
 forwarded@~0.1.0:
   version "0.1.0"
@@ -2596,7 +2584,7 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
 
-methods@1.x, methods@^1.1.1, methods@~1.1.2:
+methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
@@ -2629,7 +2617,7 @@ mime-db@~1.25.0:
   version "1.25.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
 
-mime-types@^2.1.10, mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.13, mime-types@~2.1.7:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
   dependencies:
@@ -3827,34 +3815,27 @@ strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 
-superagent@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
+superagent@^3.0.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-3.5.0.tgz#56872b8e1ee6de994035ada2e53266899af95a6d"
   dependencies:
     component-emitter "^1.2.0"
     cookiejar "^2.0.6"
     debug "^2.2.0"
     extend "^3.0.0"
-    form-data "1.0.0-rc4"
-    formidable "^1.0.17"
+    form-data "^2.1.1"
+    formidable "^1.1.1"
     methods "^1.1.1"
     mime "^1.3.4"
     qs "^6.1.0"
     readable-stream "^2.0.5"
 
-supertest-as-promised@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/supertest-as-promised/-/supertest-as-promised-4.0.2.tgz#0464f2bd256568d4a59bce84269c0548f6879f1a"
+supertest@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/supertest/-/supertest-3.0.0.tgz#8d4bb68fd1830ee07033b1c5a5a9a4021c965296"
   dependencies:
-    bluebird "^3.3.1"
-    methods "^1.1.1"
-
-supertest@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-2.0.1.tgz#a058081d788f1515d4700d7502881e6b759e44cd"
-  dependencies:
-    methods "1.x"
-    superagent "^2.0.0"
+    methods "~1.1.2"
+    superagent "^3.0.0"
 
 supports-color@3.1.2:
   version "3.1.2"


### PR DESCRIPTION
This closes https://github.com/queerviolet/bones/issues/33 and also does part of the work for https://github.com/queerviolet/bones/issues/32.

* Upgrades `supertest` to v3, which supports promises on its own.
* Fixes race condition regarding database sync.
* Clears tables after every spec — specs should be entirely independent.
* Moves some db setup logging to `debug` calls, to clean up Mocha output.
* Re-structures server tests to consistently follow this hierarchy:
  * Parent resource
    * method [& child resource]
      * authentication state

Re: the last bullet, auth state and method/sub-resource could be swapped, resulting in less duplication of setup / teardown. However I like this structure as it means the URI and method are kept together, with less comparison of the same endpoint across separate suites. Compare:

```
/api/foo
  when logged in
    GET
      does a thing
      does another thing
    POST
      does a thing
    PUT :id
      does something
  when not logged in
    GET
      does a thing
      does another thing
    PUT :id
      does something
```

vs.

```
/api/foo
  GET
    when logged in
      does a thing
      does another thing
    when not logged in
      does a thing
      does another thing
  POST
    when logged in
      does a thing
  PUT :id
    when logged in
      does something
    when not logged in
      does something
```

In the former example, endpoints are split across multiple suites, and it can be overlooked that POST requests don't get thoroughly tested. In the latter example, each endpoint is consolidated as a single suite, and it's clearer when one is "missing" alternative states.