### PR TITLE
feat(errs): delegate to Express error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "cookie-session": "^2.0.0-alpha.1",
     "enzyme": "^2.5.1",
     "express": "^4.14.0",
+    "finalhandler": "^1.0.0",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",
     "passport-github2": "^0.1.10",

--- a/server/start.js
+++ b/server/start.js
@@ -55,10 +55,12 @@ module.exports = app
   // Send index.html for anything else.
   .get('/*', (_, res) => res.sendFile(resolve(__dirname, '..', 'public', 'index.html')))
 
+  // Error middleware interceptor, delegates to built-in Express behavior.
+  // https://github.com/expressjs/express/blob/master/lib/application.js#L162
+  // https://github.com/pillarjs/finalhandler/blob/master/index.js#L172
   .use((err, req, res, next) => {
     console.log(prettyError.render(err))
-    res.status(500).send(err)
-    next()
+    next(err)
   })
 
 if (module === require.main) {

--- a/server/start.js
+++ b/server/start.js
@@ -5,6 +5,7 @@ const bodyParser = require('body-parser')
 const {resolve} = require('path')
 const passport = require('passport')
 const PrettyError = require('pretty-error')
+const finalHandler = require('finalhandler')
 // PrettyError docs: https://www.npmjs.com/package/pretty-error
 
 // Bones has a symlink from node_modules/APP to the root of the app.
@@ -55,12 +56,12 @@ module.exports = app
   // Send index.html for anything else.
   .get('/*', (_, res) => res.sendFile(resolve(__dirname, '..', 'public', 'index.html')))
 
-  // Error middleware interceptor, delegates to built-in Express behavior.
+  // Error middleware interceptor, delegates to same handler Express uses.
   // https://github.com/expressjs/express/blob/master/lib/application.js#L162
   // https://github.com/pillarjs/finalhandler/blob/master/index.js#L172
   .use((err, req, res, next) => {
-    console.log(prettyError.render(err))
-    next(err)
+    console.error(prettyError.render(err))
+    finalHandler(req, res)(err)
   })
 
 if (module === require.main) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1333,6 +1333,12 @@ debug@2.3.2, debug@^2.1.1, debug@^2.2.0:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1711,6 +1717,18 @@ finalhandler@0.5.0:
     escape-html "~1.0.3"
     on-finished "~2.3.0"
     statuses "~1.3.0"
+    unpipe "~1.0.0"
+
+finalhandler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.0.tgz#b5691c2c0912092f18ac23e9416bde5cd7dc6755"
+  dependencies:
+    debug "2.6.1"
+    encodeurl "~1.0.1"
+    escape-html "~1.0.3"
+    on-finished "~2.3.0"
+    parseurl "~1.3.1"
+    statuses "~1.3.1"
     unpipe "~1.0.0"
 
 find-cache-dir@^0.1.1:
@@ -3741,7 +3759,7 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
-statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.3.0:
+statuses@1, "statuses@>= 1.3.1 < 2", statuses@~1.3.0, statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 


### PR DESCRIPTION
Closes https://github.com/queerviolet/bones/issues/29. Benefits include:

* `err.status` /  `err.statusCode` is honored again.
* The client gets usable errors instead of empty JSON.
* Better development / production split.
* Students see how error middleware can intercept and "re-pass" errors.

For interest's & education's sake, I'm including these links as comments so people can see precisely how the built-in error handling works:

* https://github.com/expressjs/express/blob/master/lib/application.js#L162
* https://github.com/pillarjs/finalhandler/blob/master/index.js#L172