### PR TITLE
fix(passport): deserialize handles null user

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -84,7 +84,8 @@ passport.deserializeUser(
     debug('will deserialize user.id=%d', id)
     User.findById(id)
       .then(user => {
-        debug('deserialize did ok user.id=%d', user.id)
+        if (!user) debug('deserialize retrieved null user for id=%d', id)
+        else debug('deserialize did ok user.id=%d', id)
         done(null, user)
       })
       .catch(err => {


### PR DESCRIPTION
Closes https://github.com/queerviolet/bones/issues/28, which students have been having problems with. Turns out the issue was the `debug` call which was trying to access `id` whether or not `user` was an object.