### PR TITLE
feat(routing): handle 404s better

### DIFF
--- a/app/components/NotFound.jsx
+++ b/app/components/NotFound.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Link } from 'react-router'
+
+const NotFound = props => {
+  console.log(props);
+  return (
+    <div>
+      <h1>Not Found</h1>
+      <pre>{ props.location.pathname }</pre>
+      <p>is not a valid front-end route. <Link to="/">Click here</Link> to return to the home page.</p>
+    </div>
+  );
+}
+
+export default NotFound

--- a/app/components/NotFound.jsx
+++ b/app/components/NotFound.jsx
@@ -2,12 +2,16 @@ import React from 'react'
 import { Link } from 'react-router'
 
 const NotFound = props => {
-  console.log(props);
+  const {pathname} = props.location || {pathname: '<< no path >>'}
+  console.error('NotFound: %s not found (%o)', pathname, props);
   return (
     <div>
-      <h1>Not Found</h1>
-      <pre>{ props.location.pathname }</pre>
-      <p>is not a valid front-end route. <Link to="/">Click here</Link> to return to the home page.</p>
+      <h1>Sorry, I couldn't find <pre>{pathname}</pre></h1>
+      <pre>
+        {JSON.stringify(props, null, 2)}
+      </pre>      
+      <p>Lost? <Link to="/">Here's a way home.</Link></p>
+      <cite>~ xoxo, bones.</cite>
     </div>
   );
 }

--- a/app/components/NotFound.jsx
+++ b/app/components/NotFound.jsx
@@ -7,6 +7,7 @@ const NotFound = props => {
   return (
     <div>
       <h1>Sorry, I couldn't find <pre>{pathname}</pre></h1>
+      <p>The router gave me these props:</p>
       <pre>
         {JSON.stringify(props, null, 2)}
       </pre>      

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -8,6 +8,7 @@ import store from './store'
 import Jokes from './components/Jokes'
 import Login from './components/Login'
 import WhoAmI from './components/WhoAmI'
+import NotFound from './components/NotFound'
 
 const ExampleApp = connect(
   ({ auth }) => ({ user: auth })
@@ -16,7 +17,7 @@ const ExampleApp = connect(
     <div>
       <nav>
         {user ? <WhoAmI/> : <Login/>}
-      </nav> 
+      </nav>
       {children}
     </div>
 )
@@ -28,6 +29,7 @@ render (
         <IndexRedirect to="/jokes" />
         <Route path="/jokes" component={Jokes} />
       </Route>
+      <Route path='*' component={NotFound} />
     </Router>
   </Provider>,
   document.getElementById('main')

--- a/server/start.js
+++ b/server/start.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const path = require('path')
 const express = require('express')
 const bodyParser = require('body-parser')
 const {resolve} = require('path')
@@ -52,6 +53,17 @@ module.exports = app
 
   // Serve our api - ./api also requires in ../db, which syncs with our database
   .use('/api', require('./api'))
+
+  // any requests with an extension (.js, .css, etc.) turn into 404
+  .use((req, res, next) => {
+    if (path.extname(req.path).length) {
+      const err = new Error('Not found')
+      err.status = 404
+      next(err)
+    } else {
+      next()
+    }
+  })
 
   // Send index.html for anything else.
   .get('/*', (_, res) => res.sendFile(resolve(__dirname, '..', 'public', 'index.html')))


### PR DESCRIPTION
Closes #77.

* Requests for not found files (paths ending in an extension) now result in 404s instead of the index page.
* Requests for not found paths now render a 404 page in React.