### PR TITLE
Consistently use app.env

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -5,10 +5,10 @@ const debugDB = require('debug')(`${app.name}:db`) // DEBUG=your_app_name:db
 const chalk = require('chalk')
 const Sequelize = require('sequelize')
 
-const name = (process.env.DATABASE_NAME || app.name) +
+const name = (app.env.DATABASE_NAME || app.name) +
   (app.isTesting ? '_test' : '')
 
-const url = process.env.DATABASE_URL || `postgres://localhost:5432/${name}`
+const url = app.env.DATABASE_URL || `postgres://localhost:5432/${name}`
 
 debugDB(chalk.yellow(`Opening database connection to ${url}`));
 

--- a/index.js
+++ b/index.js
@@ -33,24 +33,28 @@ if (!reasonableName.test(pkg.name)) {
 // and add it to the environment.
 // Note that this needs to be in your home directory, not the project's root directory
 const env = Object.create(process.env)
-  , secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
+    , secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
 try {
-  Object.assign(env, require(secretsFile))
+  const additionalEnv = require(secretsFile)
+  Object.assign(env, additionalEnv)
+  process.env = env
+  debug('%s: %j', secretsFile, additionalEnv)
 } catch (error) {
   debug('%s: %s', secretsFile, error.message)
   debug('%s: env file not found or invalid, moving on', secretsFile)
 }
 
-const PORT = process.env.PORT || 1337
-
 module.exports = {
   get name() { return pkg.name },
   get isTesting() { return !!global.it },
   get isProduction() {
-    return process.env.NODE_ENV === 'production'
+    return env.NODE_ENV === 'production'
+  },
+  get isDevelopment() {
+    return env.NODE_ENV === 'development'
   },
   get baseUrl() {
-    return env.BASE_URL || `http://localhost:${PORT}`
+    return env.BASE_URL || `http://localhost:${env.port}`
   },
   get port() {
     return env.PORT || 1337

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build-dev": "cross-env NODE_ENV=development npm run build-watch",
     "build-branch": "bin/build-branch.sh",
     "start": "node server/start.js",
-    "start-watch": "nodemon server/start.js --watch server --watch db",
+    "start-watch": "nodemon server/start.js --watch server --watch db --watch index.js --watch package.json",
     "start-dev": "cross-env NODE_ENV=development npm run start-watch",
     "dev": "cross-env NODE_ENV=development concurrently --kill-others --prefix \"[{name}]\" --names \"BUILD,SERVE\" -c \"bgBlue.bold.black,bgGreen.bold.black\" \"npm run build-dev\" \"npm run start-dev\"",
     "test": "mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",

--- a/server/auth.js
+++ b/server/auth.js
@@ -16,7 +16,7 @@ const auth = require('express').Router()
  *
  * You can do it on the command line:
  *
- *   FACEBOOK_CLIENT_ID=abcd FACEBOOK_CLIENT_SECRET=1234 npm start
+ *   FACEBOOK_CLIENT_ID=abcd FACEBOOK_CLIENT_SECRET=1234 npm run dev
  *
  * Or, better, you can create a ~/.$your_app_name.env.json file in
  * your home directory, and set them in there:

--- a/server/start.js
+++ b/server/start.js
@@ -81,7 +81,7 @@ if (module === require.main) {
   //
   // https://nodejs.org/api/modules.html#modules_accessing_the_main_module
   const server = app.listen(
-    process.env.PORT || 1337,
+    pkg.port,
     () => {
       console.log(`--- Started HTTP Server for ${pkg.name} ---`)
       const { address, port } = server.address()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
-'use strict';
+'use strict'
 
-const LiveReloadPlugin = require('webpack-livereload-plugin');
-const devMode = process.env.NODE_ENV === 'development';
+const LiveReloadPlugin = require('webpack-livereload-plugin')
+const devMode = require('.').isDevelopment
 
 /**
  * Fast source maps rebuild quickly during development, but only give a link
@@ -10,7 +10,7 @@ const devMode = process.env.NODE_ENV === 'development';
  * usable stack traces. Set to `true` if you want to speed up development.
  */
 
-const USE_FAST_SOURCE_MAPS = false;
+const USE_FAST_SOURCE_MAPS = false
 
 module.exports = {
   entry: './app/main.jsx',
@@ -42,4 +42,4 @@ module.exports = {
       appendScriptTag: true
     })
   ] : []
-};
+}


### PR DESCRIPTION
I noticed this morning that setting PORT in `~/.${APP_NAME}.env.js` doesn't work. Fixed now.