### PR TITLE
B/decyclicize models

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-public/bundle.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+public/bundle.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: "eslint-config-standard",
+  root: true,
   parser: "babel-eslint",
   parserOptions: {
     sourceType: "module",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,14 @@
 module.exports = {
   extends: "eslint-config-standard",
+  parser: "babel-eslint",
   parserOptions: {
-    "ecmaVersion": 8
+    sourceType: "module",
+    ecmaVersion: 8
   },
+  ecmaFeatures: {
+    jsx: true,
+  },
+  plugins: ['react'],
   rules: {
     "space-before-function-paren": ["error", "never"],
     "prefer-const": "warn",
@@ -10,9 +16,19 @@ module.exports = {
     "space-infix-ops": "off",      // Until eslint #7489 lands
     "new-cap": "off",
     "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],    
+    "no-return-assign": "off",
+    "no-unused-expressions": "off",
     "one-var": "off",
     "new-parens": "off",
+    "indent": ["error", 2, {SwitchCase: 0}],
     "arrow-body-style": ["warn", "as-needed"],
+
+    "no-unused-vars": "off",
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "react/react-in-jsx-scope": "error",
+
+    "import/first": "off",
 
     // This rule enforces a comma-first style, such as
     // npm uses. I think it's great, but it can look a bit weird,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,9 +15,11 @@ module.exports = {
     "arrow-body-style": ["warn", "as-needed"],
 
     // This rule enforces a comma-first style, such as
-    // npm uses. It can look a bit weird, so we're leaving them
-    // out for now.
-    "comma-style": ["error", "first", {
+    // npm uses. I think it's great, but it can look a bit weird,
+    // so we're leaving it off for now (although stock Bones passes
+    // the linter with it on). If you decide you want to enforce
+    // this rule, change "off" to "error".
+    "comma-style": ["off", "first", {
       exceptions: {
         ArrayExpression: true,
         ObjectExpression: true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,27 @@
+module.exports = {
+  extends: "eslint-config-standard",
+  parserOptions: {
+    "ecmaVersion": 8
+  },
+  rules: {
+    "space-before-function-paren": ["error", "never"],
+    "prefer-const": "warn",
+    "comma-dangle": ["error", "only-multiline"],
+    "space-infix-ops": "off",      // Until eslint #7489 lands
+    "new-cap": "off",
+    "no-unused-vars": ["error", { "varsIgnorePattern": "^_" }],    
+    "one-var": "off",
+    "new-parens": "off",
+    "arrow-body-style": ["warn", "as-needed"],
+
+    // This rule enforces a comma-first style, such as
+    // npm uses. It can look a bit weird, so we're leaving them
+    // out for now.
+    "comma-style": ["error", "first", {
+      exceptions: {
+        ArrayExpression: true,
+        ObjectExpression: true,
+      }
+    }],
+  },
+}

--- a/app/components/Jokes.jsx
+++ b/app/components/Jokes.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component } from 'react'
 
 export default class BonesJokes extends Component {
   componentDidMount() {
@@ -17,7 +17,7 @@ export default class BonesJokes extends Component {
   render() {
     if (!this.state) { return null }
 
-    const {joke, answered} = this.state    
+    const {joke, answered} = this.state
     return (
       <div onClick={answered ? this.nextJoke : this.answer}>
         <h1>{joke.q}</h1>

--- a/app/components/Jokes.test.jsx
+++ b/app/components/Jokes.test.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
-import chai, {expect} from 'chai'                                                   
+import chai, {expect} from 'chai'
 chai.use(require('chai-enzyme')())
+
 import {shallow} from 'enzyme'
 
 import Jokes from './Jokes'
 
+/* global describe it beforeEach */
 describe('<Jokes />', () => {
   const joke = {
     q: 'Why did the skeleton write tests?',
@@ -16,10 +18,10 @@ describe('<Jokes />', () => {
     root = shallow(<Jokes />)
   )
 
-  it('shows a joke', () => {    
+  it('shows a joke', () => {
     root.setState({ joke, answered: false })
     expect(root.find('h1')).to.have.length(1)
-    expect(root.find('h1').text()).equal(joke.q)    
+    expect(root.find('h1').text()).equal(joke.q)
   })
 
   it("doesn't show the answer when state.answered=false", () => {

--- a/app/components/Login.jsx
+++ b/app/components/Login.jsx
@@ -14,7 +14,7 @@ export const Login = ({ login }) => (
 import {login} from 'APP/app/reducers/auth'
 import {connect} from 'react-redux'
 
-export default connect (
+export default connect(
   state => ({}),
   {login},
-) (Login)
+)(Login)

--- a/app/components/Login.test.jsx
+++ b/app/components/Login.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import chai, {expect} from 'chai'                                                   
+import chai, {expect} from 'chai'
 chai.use(require('chai-enzyme')())
 import {shallow} from 'enzyme'
 import {spy} from 'sinon'
@@ -7,6 +7,7 @@ chai.use(require('sinon-chai'))
 
 import {Login} from './Login'
 
+/* global describe it beforeEach */
 describe('<Login />', () => {
   let root
   beforeEach('render the root', () =>
@@ -30,7 +31,7 @@ describe('<Login />', () => {
   })
 
   describe('when submitted', () => {
-    const login = spy()    
+    const login = spy()
     const root = shallow(<Login login={login}/>)
     const submitEvent = {
       preventDefault: spy(),
@@ -43,10 +44,10 @@ describe('<Login />', () => {
     beforeEach('submit', () => {
       login.reset()
       submitEvent.preventDefault.reset()
-      root.simulate('submit', submitEvent)      
+      root.simulate('submit', submitEvent)
     })
 
-    it('calls props.login with credentials', () => {      
+    it('calls props.login with credentials', () => {
       expect(login).to.have.been.calledWith(
         submitEvent.target.username.value,
         submitEvent.target.password.value,

--- a/app/components/NotFound.jsx
+++ b/app/components/NotFound.jsx
@@ -3,18 +3,18 @@ import { Link } from 'react-router'
 
 const NotFound = props => {
   const {pathname} = props.location || {pathname: '<< no path >>'}
-  console.error('NotFound: %s not found (%o)', pathname, props);
+  console.error('NotFound: %s not found (%o)', pathname, props)
   return (
     <div>
       <h1>Sorry, I couldn't find <pre>{pathname}</pre></h1>
       <p>The router gave me these props:</p>
       <pre>
         {JSON.stringify(props, null, 2)}
-      </pre>      
+      </pre>
       <p>Lost? <Link to="/">Here's a way home.</Link></p>
       <cite>~ xoxo, bones.</cite>
     </div>
-  );
+  )
 }
 
 export default NotFound

--- a/app/components/WhoAmI.jsx
+++ b/app/components/WhoAmI.jsx
@@ -10,7 +10,7 @@ export const WhoAmI = ({ user, logout }) => (
 import {logout} from 'APP/app/reducers/auth'
 import {connect} from 'react-redux'
 
-export default connect (
+export default connect(
   ({ auth }) => ({ user: auth }),
   {logout},
-) (WhoAmI)
+)(WhoAmI)

--- a/app/components/WhoAmI.test.jsx
+++ b/app/components/WhoAmI.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import chai, {expect} from 'chai'                                                   
+import chai, {expect} from 'chai'
 chai.use(require('chai-enzyme')())
 import {shallow} from 'enzyme'
 import {spy} from 'sinon'
@@ -8,11 +8,12 @@ import {createStore} from 'redux'
 
 import WhoAmIContainer, {WhoAmI} from './WhoAmI'
 
+/* global describe it beforeEach */
 describe('<WhoAmI/>', () => {
   const user = {
     name: 'Dr. Bones',
   }
-  const logout = spy() 
+  const logout = spy()
   let root
   beforeEach('render the root', () =>
     root = shallow(<WhoAmI user={user} logout={logout}/>)
@@ -36,7 +37,7 @@ describe("<WhoAmI/>'s connection", () => {
   const state = {
     auth: {name: 'Dr. Bones'}
   }
-  
+
   let root, store, dispatch
   beforeEach('create store and render the root', () => {
     store = createStore(state => state, state)

--- a/app/main.jsx
+++ b/app/main.jsx
@@ -12,7 +12,7 @@ import NotFound from './components/NotFound'
 
 const ExampleApp = connect(
   ({ auth }) => ({ user: auth })
-) (
+)(
   ({ user, children }) =>
     <div>
       <nav>
@@ -22,7 +22,7 @@ const ExampleApp = connect(
     </div>
 )
 
-render (
+render(
   <Provider store={store}>
     <Router history={browserHistory}>
       <Route path="/" component={ExampleApp}>

--- a/app/reducers/auth.jsx
+++ b/app/reducers/auth.jsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const reducer = (state=null, action) => {
-  switch(action.type) {
+  switch (action.type) {
   case AUTHENTICATED:
     return action.user
   }

--- a/app/reducers/index.jsx
+++ b/app/reducers/index.jsx
@@ -1,7 +1,7 @@
 import { combineReducers } from 'redux'
 
 const rootReducer = combineReducers({
-  auth: require('./auth').default,  
+  auth: require('./auth').default,
 })
 
 export default rootReducer

--- a/bin/mkapplink.js
+++ b/bin/mkapplink.js
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 
+'use strict'
+
 // 'bin/setup' is a symlink pointing to this file, which makes a
 // symlink in your project's main node_modules folder that points to
 // the root of your project's directory.
 
 const chalk = require('chalk')
-const fs = require('fs')
-const {resolve} = require('path')
+    , fs = require('fs')
+    , {resolve} = require('path')
 
-const appLink = resolve(__dirname, '..', 'node_modules', 'APP')
+    , appLink = resolve(__dirname, '..', 'node_modules', 'APP')
 
-const symlinkError = error =>
+    , symlinkError = error =>
 `*******************************************************************
 ${appLink} must point to '..'
 
@@ -33,7 +35,7 @@ function makeAppSymlink() {
   console.log(`Linking '${appLink}' to '..'`)
   try {
     // fs.unlinkSync docs: https://nodejs.org/api/fs.html#fs_fs_unlinksync_path
-    try { fs.unlinkSync(appLink) } catch(swallowed) { }
+    try { fs.unlinkSync(appLink) } catch (swallowed) { }
     // fs.symlinkSync docs: https://nodejs.org/api/fs.html#fs_fs_symlinksync_target_path_type
     const linkType = process.platform === 'win32' ? 'junction' : 'dir'
     fs.symlinkSync('..', appLink, linkType)

--- a/db/index.js
+++ b/db/index.js
@@ -20,7 +20,7 @@ const db = module.exports = new Sequelize(url, {
 })
 
 // pull in our models
-require('./models')
+Object.assign(db, require('./models'))
 
 // sync the db, creating it if necessary
 function sync(force=app.isTesting, retries=0, maxRetries=5) {

--- a/db/index.js
+++ b/db/index.js
@@ -20,7 +20,7 @@ const db = module.exports = new Sequelize(url, {
   }
 })
 
-// Initiailize all our models and assign them as properties
+// Initialize all our models and assign them as properties
 // on the database object.
 //
 // This lets us use destructuring to get at them like so:

--- a/db/index.js
+++ b/db/index.js
@@ -1,18 +1,15 @@
 'use strict'
 const app = require('APP')
-const debugSQL = require('debug')('sql') // DEBUG=sql
-const debugDB = require('debug')(`${app.name}:db`) // DEBUG=your_app_name:db
-const chalk = require('chalk')
-const Sequelize = require('sequelize')
+    , debugSQL = require('debug')('sql')           // DEBUG=sql
+    , debugDB = require('debug')(`${app.name}:db`) // DEBUG=your_app_name:db
+    , chalk = require('chalk')
+    , Sequelize = require('sequelize')
 
-const name = (app.env.DATABASE_NAME || app.name) +
-  (app.isTesting ? '_test' : '')
+    , name = (app.env.DATABASE_NAME || app.name) +
+             (app.isTesting ? '_test' : '')
+    , url = app.env.DATABASE_URL || `postgres://localhost:5432/${name}`
 
-const url = app.env.DATABASE_URL || `postgres://localhost:5432/${name}`
-
-debugDB(chalk.yellow(`Opening database connection to ${url}`));
-
-// create the database instance
+debugDB(chalk.yellow(`Opening database connection to ${url}`))
 const db = module.exports = new Sequelize(url, {
   logging: debugSQL, // export DEBUG=sql in the environment to get SQL queries
   define: {
@@ -28,7 +25,7 @@ require('./models')
 // sync the db, creating it if necessary
 function sync(force=app.isTesting, retries=0, maxRetries=5) {
   return db.sync({force})
-    .then(ok => debugDB(`Synced models to db ${url}`))
+    .then(() => debugDB(`Synced models to db ${url}`))
     .catch(fail => {
       // Don't do this auto-create nonsense in prod, or
       // if we've retried too many times.
@@ -42,7 +39,7 @@ function sync(force=app.isTesting, retries=0, maxRetries=5) {
       }
       // Otherwise, do this autocreate nonsense
       debugDB(`${retries ? `[retry ${retries}]` : ''} Creating database ${name}...`)
-      return new Promise((resolve, reject) =>
+      return new Promise(resolve =>
         // 'child_process.exec' docs: https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback
         require('child_process').exec(`createdb "${name}"`, resolve)
       ).then(() => sync(true, retries + 1))

--- a/db/index.js
+++ b/db/index.js
@@ -38,7 +38,7 @@ db.didSync = db.createAndSync()
 
 // sync the db, creating it if necessary
 function createAndSync(force=app.isTesting, retries=0, maxRetries=5) {
-  db.sync({force})
+  return db.sync({force})
     .then(() => debug(`Synced models to db ${url}`))
     .catch(fail => {
       // Don't do this auto-create nonsense in prod, or
@@ -58,6 +58,4 @@ function createAndSync(force=app.isTesting, retries=0, maxRetries=5) {
         require('child_process').exec(`createdb "${name}"`, resolve)
       ).then(() => createAndSync(true, retries + 1))
     })
-
-  return db.didSync
 }

--- a/db/models/favorite.js
+++ b/db/models/favorite.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const {STRING} = require('sequelize')
+
+module.exports = db => db.define('favorites')
+
+module.exports.associations = (Favorite, {Thing, User}) => {
+  Favorite.belongsTo(Thing)
+  Favorite.belongsTo(User)
+}

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -4,9 +4,47 @@
 // so any other part of the application could call sequelize.model('User')
 // to get access to the User model.
 
-const User = require('./user')
-    , OAuth = require('./oauth')
+const app = require('APP')
+    , debug = require('debug')(`${app.name}:models`)
+    // Our model files export functions that take a database and return
+    // a model. We call these functions "meta-models" (they are models of
+    // models).
+    //
+    // This lets us avoid cyclic dependencies, which can be hard to reason
+    // about.
+    , metaModels = {
+      OAuth: require('./oauth'),
+      User: require('./user'),
+      // Add new models here.
+    }
+    , _ = require('lodash')
+    , db = require('..')
+    // Create actual model classes by calling each module's
+    // function with the database.
+    , models = _.mapValues(metaModels, defineModel => defineModel(db))
 
-OAuth.belongsTo(User)
-User.hasOne(OAuth)
-module.exports = {User}
+/*
+At this point, all our models have been created. We just need to
+create the associations between them.
+
+We pass the responsibility for this onto the models themselves:
+If they export an `associations` method, we'll call it, passing
+in all the models that have been defined.
+
+This lets us move the association logic to the model files,
+so all the knowledge about the structure of each model remains
+self-contained.
+*/
+Object.keys(metaModels)
+  .forEach(name => {
+    const {associations} = metaModels[name]
+    if (typeof associations === 'function') {
+      debug('associating model %s', name)
+      // Metamodel::associations(self: Model, others: {[name: String]: Model}) -> ()
+      //
+      // Associate self with others.
+      associations.call(metaModels[name], models[name], models)
+    }
+  })
+
+module.exports = models

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -1,11 +1,11 @@
-'use strict';
+'use strict'
 
 // Require our models. Running each module registers the model into sequelize
 // so any other part of the application could call sequelize.model('User')
 // to get access to the User model.
 
 const User = require('./user')
-const OAuth = require('./oauth')
+    , OAuth = require('./oauth')
 
 OAuth.belongsTo(User)
 User.hasOne(OAuth)

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -37,9 +37,9 @@ module.exports = db => {
   This lets us move the association logic to the model files,
   so all the knowledge about the structure of each model remains
   self-contained.
-  
+
   The Sequelize docs suggest a similar setup:
-  
+
   https://github.com/sequelize/express-example#sequelize-setup
   */
   Object.keys(metaModels)

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -37,6 +37,10 @@ module.exports = db => {
   This lets us move the association logic to the model files,
   so all the knowledge about the structure of each model remains
   self-contained.
+  
+  The Sequelize docs suggest a similar setup:
+  
+  https://github.com/sequelize/express-example#sequelize-setup
   */
   Object.keys(metaModels)
     .forEach(name => {

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -7,7 +7,7 @@
 const app = require('APP')
     , debug = require('debug')(`${app.name}:models`)
     // Our model files export functions that take a database and return
-    // a model. We call these functions "meta-models" (they are models of
+    // a model. We call these functions "meta models" (they are models of
     // models).
     //
     // This lets us avoid cyclic dependencies, which can be hard to reason
@@ -15,36 +15,38 @@ const app = require('APP')
     , metaModels = {
       OAuth: require('./oauth'),
       User: require('./user'),
-      // Add new models here.
+      // ---------- Add new models here ----------
     }
-    , _ = require('lodash')
-    , db = require('..')
-    // Create actual model classes by calling each module's
-    // function with the database.
-    , models = _.mapValues(metaModels, defineModel => defineModel(db))
+    , {mapValues} = require('lodash')
 
-/*
-At this point, all our models have been created. We just need to
-create the associations between them.
+module.exports = db => {
+  // Create actual model classes by calling each meta model with the
+  // database.
+  const models = mapValues(metaModels, defineModel => defineModel(db))
 
-We pass the responsibility for this onto the models themselves:
-If they export an `associations` method, we'll call it, passing
-in all the models that have been defined.
+  /*
+  At this point, all our models have been created. We just need to
+  create the associations between them.
 
-This lets us move the association logic to the model files,
-so all the knowledge about the structure of each model remains
-self-contained.
-*/
-Object.keys(metaModels)
-  .forEach(name => {
-    const {associations} = metaModels[name]
-    if (typeof associations === 'function') {
-      debug('associating model %s', name)
-      // Metamodel::associations(self: Model, others: {[name: String]: Model}) -> ()
-      //
-      // Associate self with others.
-      associations.call(metaModels[name], models[name], models)
-    }
-  })
+  We pass the responsibility for this onto the models themselves:
+  If they export an `associations` method, we'll call it, passing
+  in all the models that have been defined.
 
-module.exports = models
+  This lets us move the association logic to the model files,
+  so all the knowledge about the structure of each model remains
+  self-contained.
+  */
+  Object.keys(metaModels)
+    .forEach(name => {
+      const {associations} = metaModels[name]
+      if (typeof associations === 'function') {
+        debug('associating model %s', name)
+        // Metamodel::associations(self: Model, others: {[name: String]: Model}) -> ()
+        //
+        // Associate self with others.
+        associations.call(metaModels[name], models[name], models)
+      }
+    })
+
+  return models
+}

--- a/db/models/index.js
+++ b/db/models/index.js
@@ -15,6 +15,8 @@ const app = require('APP')
     , metaModels = {
       OAuth: require('./oauth'),
       User: require('./user'),
+      Thing: require('./thing'),
+      Favorite: require('./favorite'),
       // ---------- Add new models here ----------
     }
     , {mapValues} = require('lodash')

--- a/db/models/oauth.js
+++ b/db/models/oauth.js
@@ -2,23 +2,23 @@
 
 const app = require('APP')
     , debug = require('debug')(`${app.name}:oauth`)
-    , Sequelize = require('sequelize')
+    , {STRING, JSON} = require('sequelize')
 
 module.exports = db => {
   const OAuth = db.define('oauths', {
-    uid: Sequelize.STRING,
-    provider: Sequelize.STRING,
+    uid: STRING,
+    provider: STRING,
 
     // OAuth v2 fields
-    accessToken: Sequelize.STRING,
-    refreshToken: Sequelize.STRING,
+    accessToken: STRING,
+    refreshToken: STRING,
 
     // OAuth v1 fields
-    token: Sequelize.STRING,
-    tokenSecret: Sequelize.STRING,
+    token: STRING,
+    tokenSecret: STRING,
 
     // The whole profile as JSON
-    profileJson: Sequelize.JSON,
+    profileJson: JSON,
   }, {
     // Further reading on indexes:
     // 1. Sequelize and indexes: http://docs.sequelizejs.com/en/2.0/docs/models-definition/#indexes

--- a/db/models/oauth.js
+++ b/db/models/oauth.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const app = require('APP')
-const debug = require('debug')(`${app.name}:oauth`)
-const Sequelize = require('sequelize')
-const db = require('APP/db')
-const User = require('./user')
+    , debug = require('debug')(`${app.name}:oauth`)
+    , Sequelize = require('sequelize')
+    , db = require('APP/db')
+    , User = require('./user')
 
 const OAuth = db.define('oauths', {
   uid: Sequelize.STRING,
@@ -24,7 +24,7 @@ const OAuth = db.define('oauths', {
   // Further reading on indexes:
   // 1. Sequelize and indexes: http://docs.sequelizejs.com/en/2.0/docs/models-definition/#indexes
   // 2. Postgres documentation: https://www.postgresql.org/docs/9.1/static/indexes.html
-	indexes: [{fields: ['uid'], unique: true,}],
+  indexes: [{fields: ['uid'], unique: true}],
 })
 
 // OAuth.V2 is a default argument for the OAuth.setupStrategy method - it's our callback function that will execute when the user has successfully logged in
@@ -79,7 +79,7 @@ OAuth.setupStrategy =
         .map(k => config[k])
         .filter(value => typeof value === 'undefined')
   if (undefinedKeys.length) {
-    for (let key in config) {
+    for (const key in config) {
       if (!config[key]) debug('provider:%s: needs environment var %s', provider, key)
     }
     debug('provider:%s will not initialize', provider)

--- a/db/models/oauth.js
+++ b/db/models/oauth.js
@@ -3,92 +3,100 @@
 const app = require('APP')
     , debug = require('debug')(`${app.name}:oauth`)
     , Sequelize = require('sequelize')
-    , db = require('APP/db')
-    , User = require('./user')
 
-const OAuth = db.define('oauths', {
-  uid: Sequelize.STRING,
-  provider: Sequelize.STRING,
+module.exports = db => {
+  const OAuth = db.define('oauths', {
+    uid: Sequelize.STRING,
+    provider: Sequelize.STRING,
 
-  // OAuth v2 fields
-  accessToken: Sequelize.STRING,
-  refreshToken: Sequelize.STRING,
+    // OAuth v2 fields
+    accessToken: Sequelize.STRING,
+    refreshToken: Sequelize.STRING,
 
-  // OAuth v1 fields
-  token: Sequelize.STRING,
-  tokenSecret: Sequelize.STRING,
+    // OAuth v1 fields
+    token: Sequelize.STRING,
+    tokenSecret: Sequelize.STRING,
 
-  // The whole profile as JSON
-  profileJson: Sequelize.JSON,
-}, {
-  // Further reading on indexes:
-  // 1. Sequelize and indexes: http://docs.sequelizejs.com/en/2.0/docs/models-definition/#indexes
-  // 2. Postgres documentation: https://www.postgresql.org/docs/9.1/static/indexes.html
-  indexes: [{fields: ['uid'], unique: true}],
-})
-
-// OAuth.V2 is a default argument for the OAuth.setupStrategy method - it's our callback function that will execute when the user has successfully logged in
-OAuth.V2 = (accessToken, refreshToken, profile, done) =>
-  OAuth.findOrCreate({
-    where: {
-      provider: profile.provider,
-      uid: profile.id,
-    }
+    // The whole profile as JSON
+    profileJson: Sequelize.JSON,
+  }, {
+    // Further reading on indexes:
+    // 1. Sequelize and indexes: http://docs.sequelizejs.com/en/2.0/docs/models-definition/#indexes
+    // 2. Postgres documentation: https://www.postgresql.org/docs/9.1/static/indexes.html
+    indexes: [{fields: ['uid'], unique: true}],
   })
-  .spread(oauth => {
-    debug(profile)
-    debug('provider:%s will log in user:{name=%s uid=%s}',
-      profile.provider,
-      profile.displayName,
-      profile.id
+
+  // OAuth.V2 is a default argument for the OAuth.setupStrategy method - it's our callback function that will execute when the user has successfully logged in
+  OAuth.V2 = (accessToken, refreshToken, profile, done) =>
+    OAuth.findOrCreate({
+      where: {
+        provider: profile.provider,
+        uid: profile.id,
+      }
+    })
+    .spread(oauth => {
+      debug(profile)
+      debug('provider:%s will log in user:{name=%s uid=%s}',
+        profile.provider,
+        profile.displayName,
+        profile.id
+      )
+      oauth.profileJson = profile
+      oauth.accessToken = accessToken
+
+      // db.Promise.props is a Bluebird.js method; basically like "all" but for an object whose properties might contain promises.
+      // Docs: http://bluebirdjs.com/docs/api/promise.props.html
+      return db.Promise.props({
+        oauth,
+        user: oauth.getUser(),
+        _saveProfile: oauth.save(),
+      })
+    })
+    .then(({ oauth, user }) => user ||
+      OAuth.User.create({
+        name: profile.displayName,
+      })
+      .then(user => db.Promise.props({
+        user,
+        _setOauthUser: oauth.setUser(user)
+      }))
+      .then(({user}) => user)
     )
-    oauth.profileJson = profile
-    oauth.accessToken = accessToken
+    .then(user => done(null, user))
+    .catch(done)
 
-    // db.Promise.props is a Bluebird.js method; basically like "all" but for an object whose properties might contain promises.
-    // Docs: http://bluebirdjs.com/docs/api/promise.props.html
-    return db.Promise.props({
-      oauth,
-      user: oauth.getUser(),
-      _saveProfile: oauth.save(),
-    })
-  })
-  .then(({ oauth, user }) => user ||
-    User.create({
-      name: profile.displayName,
-    })
-    .then(user => db.Promise.props({
-      user,
-      _setOauthUser: oauth.setUser(user)
-    }))
-    .then(({user}) => user)
-  )
-  .then(user => done(null, user))
-  .catch(done)
-
-// setupStrategy is a wrapper around passport.use, and is called in authentication routes in server/auth.js
-OAuth.setupStrategy =
-({
-  provider,
-  strategy,
-  config,
-  oauth=OAuth.V2,
-  passport
-}) => {
-  const undefinedKeys = Object.keys(config)
-        .map(k => config[k])
-        .filter(value => typeof value === 'undefined')
-  if (undefinedKeys.length) {
-    for (const key in config) {
-      if (!config[key]) debug('provider:%s: needs environment var %s', provider, key)
+  // setupStrategy is a wrapper around passport.use, and is called in authentication routes in server/auth.js
+  OAuth.setupStrategy =
+  ({
+    provider,
+    strategy,
+    config,
+    oauth=OAuth.V2,
+    passport
+  }) => {
+    const undefinedKeys = Object.keys(config)
+          .map(k => config[k])
+          .filter(value => typeof value === 'undefined')
+    if (undefinedKeys.length) {
+      for (const key in config) {
+        if (!config[key]) debug('provider:%s: needs environment var %s', provider, key)
+      }
+      debug('provider:%s will not initialize', provider)
+      return
     }
-    debug('provider:%s will not initialize', provider)
-    return
+
+    debug('initializing provider:%s', provider)
+
+    passport.use(new strategy(config, oauth))
   }
 
-  debug('initializing provider:%s', provider)
-
-  passport.use(new strategy(config, oauth))
+  return OAuth
 }
 
-module.exports = OAuth
+module.exports.associations = (OAuth, {User}) => {
+  // Create a static association between the OAuth and User models.
+  // This lets us refer to OAuth.User above, when we need to create
+  // a user.
+  OAuth.User = User
+  OAuth.belongsTo(User)
+}

--- a/db/models/thing.js
+++ b/db/models/thing.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const {STRING} = require('sequelize')
+
+module.exports = db => db.define('things', {
+  name: STRING,
+})
+
+module.exports.associations = (Thing, {User, Favorite}) => {
+  Thing.belongsToMany(User, {as: 'lovers', through: Favorite})
+}

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -2,12 +2,12 @@
 
 // bcrypt docs: https://www.npmjs.com/package/bcrypt
 const bcrypt = require('bcryptjs')
-    , Sequelize = require('sequelize')
+    , {STRING, VIRTUAL} = require('sequelize')
 
 module.exports = db => db.define('users', {
-  name: Sequelize.STRING,
+  name: STRING,
   email: {
-    type: Sequelize.STRING,
+    type: STRING,
     validate: {
       isEmail: true,
       notEmpty: true,
@@ -15,8 +15,8 @@ module.exports = db => db.define('users', {
   },
 
   // We support oauth, so users may or may not have passwords.
-  password_digest: Sequelize.STRING, // This column stores the hashed password in the DB, via the beforeCreate/beforeUpdate hooks
-  password: Sequelize.VIRTUAL // Note that this is a virtual, and not actually stored in DB
+  password_digest: STRING, // This column stores the hashed password in the DB, via the beforeCreate/beforeUpdate hooks
+  password: VIRTUAL // Note that this is a virtual, and not actually stored in DB
 }, {
   indexes: [{fields: ['email'], unique: true}],
   hooks: {

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -35,8 +35,9 @@ module.exports = db => db.define('users', {
   }
 })
 
-module.exports.associations = (User, {OAuth}) => {
+module.exports.associations = (User, {OAuth, Thing, Favorite}) => {
   User.hasOne(OAuth)
+  User.belongsToMany(Thing, {as: 'favorites', through: Favorite})
 }
 
 function setEmailAndPassword(user) {

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -2,24 +2,24 @@
 
 // bcrypt docs: https://www.npmjs.com/package/bcrypt
 const bcrypt = require('bcryptjs')
-const Sequelize = require('sequelize')
-const db = require('APP/db')
+    , Sequelize = require('sequelize')
+    , db = require('APP/db')
 
 const User = db.define('users', {
   name: Sequelize.STRING,
   email: {
     type: Sequelize.STRING,
     validate: {
-			isEmail: true,
-			notEmpty: true,
-		}
+      isEmail: true,
+      notEmpty: true,
+    }
   },
 
   // We support oauth, so users may or may not have passwords.
   password_digest: Sequelize.STRING, // This column stores the hashed password in the DB, via the beforeCreate/beforeUpdate hooks
-	password: Sequelize.VIRTUAL // Note that this is a virtual, and not actually stored in DB
+  password: Sequelize.VIRTUAL // Note that this is a virtual, and not actually stored in DB
 }, {
-	indexes: [{fields: ['email'], unique: true,}],
+  indexes: [{fields: ['email'], unique: true}],
   hooks: {
     beforeCreate: setEmailAndPassword,
     beforeUpdate: setEmailAndPassword,
@@ -41,11 +41,11 @@ function setEmailAndPassword(user) {
   if (!user.password) return Promise.resolve(user)
 
   return new Promise((resolve, reject) =>
-	  bcrypt.hash(user.get('password'), 10, (err, hash) => {
-		  if (err) reject(err)
-		  user.set('password_digest', hash)
+    bcrypt.hash(user.get('password'), 10, (err, hash) => {
+      if (err) return reject(err)
+      user.set('password_digest', hash)
       resolve(user)
-	  })
+    })
   )
 }
 

--- a/db/models/user.js
+++ b/db/models/user.js
@@ -3,9 +3,8 @@
 // bcrypt docs: https://www.npmjs.com/package/bcrypt
 const bcrypt = require('bcryptjs')
     , Sequelize = require('sequelize')
-    , db = require('APP/db')
 
-const User = db.define('users', {
+module.exports = db => db.define('users', {
   name: Sequelize.STRING,
   email: {
     type: Sequelize.STRING,
@@ -36,6 +35,10 @@ const User = db.define('users', {
   }
 })
 
+module.exports.associations = (User, {OAuth}) => {
+  User.hasOne(OAuth)
+}
+
 function setEmailAndPassword(user) {
   user.email = user.email && user.email.toLowerCase()
   if (!user.password) return Promise.resolve(user)
@@ -48,5 +51,3 @@ function setEmailAndPassword(user) {
     })
   )
 }
-
-module.exports = User

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -1,11 +1,12 @@
 'use strict'
 
 const db = require('APP/db')
-const User = require('./user')
-const {expect} = require('chai')
+    , User = require('./user')
+    , {expect} = require('chai')
+
+/* global describe it before afterEach */
 
 describe('User', () => {
-
   before('Await database sync', () => db.didSync)
   afterEach('Clear the tables', () => db.truncate({ cascade: true }))
 

--- a/db/models/user.test.js
+++ b/db/models/user.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const db = require('APP/db')
-    , User = require('./user')
+    , {User} = db
     , {expect} = require('chai')
 
 /* global describe it before afterEach */

--- a/db/seed.js
+++ b/db/seed.js
@@ -21,7 +21,15 @@ const things = seed(Thing)({
 })
 
 const favorites = seed(Favorite)(
+  // We're specifying a function here, rather than just a rows object.
+  // Using a function lets us receive the previously-seeded rows (the seed
+  // function does this wiring for us).
+  //
+  // This lets us reference previously-created rows in order to create the join
+  // rows.
   ({users, things}) => ({
+    // The easiest way to seed associations seems to be to just create rows
+    // in the join table.
     'obama loves surfing': {user_id: users.barack.id, thing_id: things.surfing.id},
     'god is into smiting': {user_id: users.god.id, thing_id: things.smiting.id},
     'obama loves puppies': {user_id: users.barack.id, thing_id: things.puppies.id},
@@ -29,21 +37,25 @@ const favorites = seed(Favorite)(
   })
 )
 
-db.didSync
-  .then(() => db.sync({force: true}))
-  .then(() => Promise.props({
-    users: users(),
-    things: things(),
-  }))
-  .then(favorites)
-  .finally(() => db.close())
+if (module === require.main) {
+  db.didSync
+    .then(() => db.sync({force: true}))
+    .then(() => ({users, things}))
+    .then(favorites)
+    .finally(() => db.close())
+}
 
 const {mapValues} = require('lodash')
 
+// seed(Model: Sequelize.Model) -> (rows: Function|Object) -> (others?: )
 function seed(Model) {
   return rows => others => {
     if (typeof rows === 'function') {
-      rows = Promise.props(others).then(rows)
+      rows = Promise.props(
+        mapValues(others,
+          other =>
+            typeof other === 'function' ? other() : other))
+        .then(rows)
     }
 
     return Promise.resolve(rows)
@@ -60,3 +72,5 @@ function seed(Model) {
       })
   }
 }
+
+module.exports = Object.assign(seed, {users, things, favorites})

--- a/db/seed.js
+++ b/db/seed.js
@@ -71,6 +71,7 @@ if (module === require.main) {
   db.didSync
     .then(() => db.sync({force: true}))
     .then(seedEverything)
+    .finally(() => process.exit(0))
 }
 
 class BadRow extends Error {

--- a/db/seed.js
+++ b/db/seed.js
@@ -34,9 +34,12 @@ const favorites = seed(Favorite,
   ({users, things}) => ({
     // The easiest way to seed associations seems to be to just create rows
     // in the join table.
-    'obama loves surfing': {
-      user_id: users.barack.id,
-      thing_id: things.surfing.id
+    'obama loves surfing': {      
+      user_id: users.barack.id,    // users.barack is an instance of the User model
+                                   // that we created in the user seed above.
+                                   // The seed function wires the promises so that it'll
+                                   // have been created already.
+      thing_id: things.surfing.id  // Same thing for things.
     },
     'god is into smiting': {
       user_id: users.god.id,

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,7 +1,7 @@
 const db = require('APP/db')
     , {User, Thing, Favorite, Promise} = db
 
-const users = seed(User)({
+const users = seed(User, {
   god: {
     email: 'god@example.com',
     name: 'So many names',
@@ -14,61 +14,110 @@ const users = seed(User)({
   },
 })
 
-const things = seed(Thing)({
+const things = seed(Thing, {
   surfing: {name: 'surfing'},
   smiting: {name: 'smiting'},
   puppies: {name: 'puppies'},
 })
 
-const favorites = seed(Favorite)(
+const favorites = seed(Favorite,
   // We're specifying a function here, rather than just a rows object.
   // Using a function lets us receive the previously-seeded rows (the seed
   // function does this wiring for us).
   //
   // This lets us reference previously-created rows in order to create the join
-  // rows.
+  // rows. We can reference them by the names we used above (which is why we used
+  // Objects above, rather than just arrays).
   ({users, things}) => ({
     // The easiest way to seed associations seems to be to just create rows
     // in the join table.
-    'obama loves surfing': {user_id: users.barack.id, thing_id: things.surfing.id},
-    'god is into smiting': {user_id: users.god.id, thing_id: things.smiting.id},
-    'obama loves puppies': {user_id: users.barack.id, thing_id: things.puppies.id},
-    'god loves puppies': {user_id: users.god.id, thing_id: things.puppies.id},
+    'obama loves surfing': {
+      user_id: users.barack.id,
+      thing_id: things.surfing.id
+    },
+    'god is into smiting': {
+      user_id: users.god.id,
+      thing_id: things.smiting.id
+    },
+    'obama loves puppies': {
+      user_id: users.barack.id,
+      thing_id: things.puppies.id
+    },
+    'god loves puppies': {
+      user_id: users.god.id,
+      thing_id: things.puppies.id
+    },
   })
 )
 
 if (module === require.main) {
   db.didSync
     .then(() => db.sync({force: true}))
-    .then(() => ({users, things}))
+    .then(() => Promise.props({
+      users: users(),
+      things: things(),
+    }))
     .then(favorites)
     .finally(() => db.close())
 }
 
 const {mapValues} = require('lodash')
 
-// seed(Model: Sequelize.Model) -> (rows: Function|Object) -> (others?: )
-function seed(Model) {
-  return rows => others => {
+class BadRow extends Error {
+  constructor(key, row, error) {
+    super(error)
+    this.cause = error
+    this.row = row
+    this.key = key
+  }
+
+  toString() {
+    return `[${this.key}] ${this.cause} while creating ${JSON.stringify(this.row, 0, 2)}\n${this.cause.stack}`
+  }
+}
+
+// seed(Model: Sequelize.Model, rows: Function|Object) ->
+//   (others?: {...Function|Object}) -> Promise<Seeded>
+//
+// Takes a model and either an Object describing rows to insert,
+// or a function that when called, returns the same.
+//
+// The function form can be used to initialize rows that reference
+// other models.
+function seed(Model, rows) {
+  return (others={}) => {
     if (typeof rows === 'function') {
       rows = Promise.props(
         mapValues(others,
           other =>
+            // Is other a function? If so, call it. Otherwise, leave it alone.
             typeof other === 'function' ? other() : other))
         .then(rows)
     }
 
     return Promise.resolve(rows)
       .then(rows => Promise.props(
-        mapValues(rows, row =>
-          Promise.props(row)
-            .then(row => Model.create(row))
-      )))
+        Object.keys(rows)
+          .map(key => {
+            const row = rows[key]
+            return {
+              key,
+              value: Promise.props(row)
+                .then(row => Model.create(row)
+                  .catch(error => { throw new BadRow(key, row, error) })
+                )
+            }
+          }).reduce(
+            (all, one) => Object.assign({}, all, {[one.key]: one.value}),
+            {}
+          )
+        )
+      )
       .then(seeded => {
         console.log(`Seeded ${Object.keys(seeded).length} ${Model.name} OK`)
         return seeded
       }).catch(error => {
-        console.error(`Error seeding ${Model.name}`, error)
+        console.error(`Error seeding ${Model.name}: ${error} \n${error.stack}`)
       })
   }
 }

--- a/db/seed.js
+++ b/db/seed.js
@@ -34,7 +34,7 @@ const favorites = seed(Favorite,
   ({users, things}) => ({
     // The easiest way to seed associations seems to be to just create rows
     // in the join table.
-    'obama loves surfing': {      
+    'obama loves surfing': {
       user_id: users.barack.id,    // users.barack is an instance of the User model
                                    // that we created in the user seed above.
                                    // The seed function wires the promises so that it'll

--- a/db/seed.js
+++ b/db/seed.js
@@ -4,6 +4,17 @@ const db = require('APP/db')
     , {User, Thing, Favorite, Promise} = db
     , {mapValues} = require('lodash')
 
+function seedEverything() {
+  const seeded = {
+    users: users(),
+    things: things(),
+  }
+
+  seeded.favorites = favorites(seeded)
+
+  return Promise.props(seeded)
+}
+
 const users = seed(User, {
   god: {
     email: 'god@example.com',
@@ -55,17 +66,6 @@ const favorites = seed(Favorite,
     },
   })
 )
-
-function seedEverything() {
-  const seeded = {
-    users: users(),
-    things: things(),
-  }
-
-  seeded.favorites = favorites(seeded)
-
-  return seeded
-}
 
 if (module === require.main) {
   db.didSync

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,12 +1,62 @@
 const db = require('APP/db')
-    , seedUsers = () => db.Promise.map([
-      {name: 'so many', email: 'god@example.com', password: '1234'},
-      {name: 'Barack Obama', email: 'barack@example.gov', password: '1234'},
-    ], user => db.model('users').create(user))
+    , {User, Thing, Favorite, Promise} = db
+
+const users = seed(User)({
+  god: {
+    email: 'god@example.com',
+    name: 'So many names',
+    password: '1234',
+  },
+  barack: {
+    name: 'Barack Obama',
+    email: 'barack@example.gov',
+    password: '1234'
+  },
+})
+
+const things = seed(Thing)({
+  surfing: {name: 'surfing'},
+  smiting: {name: 'smiting'},
+  puppies: {name: 'puppies'},
+})
+
+const favorites = seed(Favorite)(
+  ({users, things}) => ({
+    'obama loves surfing': {user_id: users.barack.id, thing_id: things.surfing.id},
+    'god is into smiting': {user_id: users.god.id, thing_id: things.smiting.id},
+    'obama loves puppies': {user_id: users.barack.id, thing_id: things.puppies.id},
+    'god loves puppies': {user_id: users.god.id, thing_id: things.puppies.id},
+  })
+)
 
 db.didSync
   .then(() => db.sync({force: true}))
-  .then(seedUsers)
-  .then(users => console.log(`Seeded ${users.length} users OK`))
-  .catch(error => console.error(error))
+  .then(() => Promise.props({
+    users: users(),
+    things: things(),
+  }))
+  .then(favorites)
   .finally(() => db.close())
+
+const {mapValues} = require('lodash')
+
+function seed(Model) {
+  return rows => others => {
+    if (typeof rows === 'function') {
+      rows = Promise.props(others).then(rows)
+    }
+
+    return Promise.resolve(rows)
+      .then(rows => Promise.props(
+        mapValues(rows, row =>
+          Promise.props(row)
+            .then(row => Model.create(row))
+      )))
+      .then(seeded => {
+        console.log(`Seeded ${Object.keys(seeded).length} ${Model.name} OK`)
+        return seeded
+      }).catch(error => {
+        console.error(`Error seeding ${Model.name}`, error)
+      })
+  }
+}

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,13 +1,12 @@
 const db = require('APP/db')
-
-const seedUsers = () => db.Promise.map([
-  {name: 'so many', email: 'god@example.com', password: '1234'},
-  {name: 'Barack Obama', email: 'barack@example.gov', password: '1234'},
-], user => db.model('users').create(user))
+    , seedUsers = () => db.Promise.map([
+      {name: 'so many', email: 'god@example.com', password: '1234'},
+      {name: 'Barack Obama', email: 'barack@example.gov', password: '1234'},
+    ], user => db.model('users').create(user))
 
 db.didSync
   .then(() => db.sync({force: true}))
   .then(seedUsers)
   .then(users => console.log(`Seeded ${users.length} users OK`))
-  .catch(error => console.error(error))    
+  .catch(error => console.error(error))
   .finally(() => db.close())

--- a/db/seed.js
+++ b/db/seed.js
@@ -1,5 +1,8 @@
+'use strict'
+
 const db = require('APP/db')
     , {User, Thing, Favorite, Promise} = db
+    , {mapValues} = require('lodash')
 
 const users = seed(User, {
   god: {
@@ -50,18 +53,22 @@ const favorites = seed(Favorite,
   })
 )
 
+function seedEverything() {
+  const seeded = {
+    users: users(),
+    things: things(),
+  }
+
+  seeded.favorites = favorites(seeded)
+
+  return seeded
+}
+
 if (module === require.main) {
   db.didSync
     .then(() => db.sync({force: true}))
-    .then(() => Promise.props({
-      users: users(),
-      things: things(),
-    }))
-    .then(favorites)
-    .finally(() => db.close())
+    .then(seedEverything)
 }
-
-const {mapValues} = require('lodash')
 
 class BadRow extends Error {
   constructor(key, row, error) {
@@ -72,7 +79,7 @@ class BadRow extends Error {
   }
 
   toString() {
-    return `[${this.key}] ${this.cause} while creating ${JSON.stringify(this.row, 0, 2)}\n${this.cause.stack}`
+    return `[${this.key}] ${this.cause} while creating ${JSON.stringify(this.row, 0, 2)}`
   }
 }
 
@@ -80,7 +87,9 @@ class BadRow extends Error {
 //   (others?: {...Function|Object}) -> Promise<Seeded>
 //
 // Takes a model and either an Object describing rows to insert,
-// or a function that when called, returns the same.
+// or a function that when called, returns rows to insert. returns
+// a function that will seed the DB when called and resolve with
+// a Promise of the object of all seeded rows.
 //
 // The function form can be used to initialize rows that reference
 // other models.
@@ -91,8 +100,8 @@ function seed(Model, rows) {
         mapValues(others,
           other =>
             // Is other a function? If so, call it. Otherwise, leave it alone.
-            typeof other === 'function' ? other() : other))
-        .then(rows)
+            typeof other === 'function' ? other() : other)
+      ).then(rows)
     }
 
     return Promise.resolve(rows)

--- a/dev.js
+++ b/dev.js
@@ -35,7 +35,7 @@ function task(command, {
             PATH: [ path.join(app.root, 'node_modules', '.bin')
                   , process.env.PATH ].join(path.delimiter)
           })
-        }).on('error', error => stderr(error))
+        }).on('error', stderr)
           .on('exit', (code, signal) => {
             stderr(`Exited with code ${code}`)
             if (signal) stderr(`Exited with signal ${signal}`)

--- a/dev.js
+++ b/dev.js
@@ -16,7 +16,7 @@ const app = require('.')
 
 function run(tasks) {
   Object.keys(tasks)
-    .map(name => tasks[name](name, tasks[name]))
+    .map(name => tasks[name](name))
 }
 
 function task(command, {

--- a/dev.js
+++ b/dev.js
@@ -62,7 +62,7 @@ function log({
 
 const dateformat = require('dateformat')
 function timestamp() {
-  return dateformat('yyyy-MM-dd HH:MM:ss (Z)')
+  return dateformat('yyyy-mm-dd HH:MM:ss (Z)')
 }
 
 function none(x) { return x }

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,68 @@
+/**
+ * Concurrently run our various dev tasks.
+ *
+ * Usage: node dev
+ **/
+
+const app = require('.')
+    , chalk = require('chalk'), {bold} = chalk
+    , {red, green, blue, cyan, yellow} = bold
+    , dev = module.exports = () => run({
+      server: task(app.package.scripts['start-watch'], {color: blue}),
+      build: task(app.package.scripts['build-watch'], {color: green}),
+      lint: task(app.package.scripts['lint-watch'], {color: cyan}),
+      test: task(app.package.scripts['test-watch'], {color: yellow})
+    })
+
+function run(tasks) {
+  Object.keys(tasks)
+    .map(name => tasks[name](name, tasks[name]))
+}
+
+function task(command, {
+  spawn=require('child_process').spawn,
+  color
+}={}) {
+  return name => {
+    const stdout = log({name, color}, process.stdout)
+        , stderr = log({name, color, text: red}, process.stderr)
+        , proc = spawn(command, {
+          shell: true,
+          stdio: 'pipe',
+          env: Object.assign({}, process.env, {
+            NODE_ENV: 'development',
+            PATH: `${app.root}/node_modules/.bin:${process.env.PATH}`
+          })
+        }).on('error', error => stderr(error))
+          .on('exit', (code, signal) => {
+            stderr(`Exited with code ${code}`)
+            if (signal) stderr(`Exited with signal ${signal}`)
+          })
+    proc.stdout.on('data', stdout)
+    proc.stderr.on('data', stderr)
+  }
+}
+
+function log({
+  name,
+  ts=timestamp,
+  color=none,
+  text=none,
+}, out=process.stdout) {
+  return data => data.toString()
+    // Strip out screen-clearing control sequences, which really
+    // muck up the output.
+    .replace('\u001b[2J', '')
+    .replace('\u001b[1;3H', '')
+    .split('\n')
+    .forEach(line => out.write(`${color(`${ts()} ${name}   \t⎹ `)}${text(line)}\n`))
+}
+
+const dateformat = require('dateformat')
+function timestamp() {
+  return dateformat('yyyy-MM-dd HH:MM:ss (Z)')
+}
+
+function none(x) { return x }
+
+if (module === require.main) { dev() }

--- a/dev.js
+++ b/dev.js
@@ -21,6 +21,7 @@ function run(tasks) {
 
 function task(command, {
   spawn=require('child_process').spawn,
+  path=require('path'),
   color
 }={}) {
   return name => {
@@ -31,7 +32,8 @@ function task(command, {
           stdio: 'pipe',
           env: Object.assign({}, process.env, {
             NODE_ENV: 'development',
-            PATH: `${app.root}/node_modules/.bin:${process.env.PATH}`
+            PATH: [ path.join(app.root, 'node_modules', '.bin')
+                  , process.env.PATH ].join(path.delimiter)
           })
         }).on('error', error => stderr(error))
           .on('exit', (code, signal) => {

--- a/index.js
+++ b/index.js
@@ -19,11 +19,11 @@ Please change it in ${__dirname}/package.json
   ~ xoxo, bones
 ********************************************************************`
 
-    , reasonableName = /^[a-z0-9\-_]+$/
-
-    // RegExp.test docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
-    , _packageDoesntHaveAName = (name =>
-        reasonableName.test(name) || console.error(chalk.red(nameError)))()
+const reasonableName = /^[a-z0-9\-_]+$/
+// RegExp.test docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
+if (!reasonableName.test(pkg.name)) {
+  console.error(chalk.red(nameError))
+}
 
 // This will load a secrets file from
 //
@@ -32,7 +32,7 @@ Please change it in ${__dirname}/package.json
 //
 // and add it to the environment.
 // Note that this needs to be in your home directory, not the project's root directory
-    , env = Object.create(process.env)
+const env = Object.create(process.env)
     , secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
 
 try {
@@ -59,6 +59,9 @@ module.exports = {
   },
   get port() {
     return env.PORT || 1337
+  },
+  get root() {
+    return __dirname
   },
   package: pkg,
   env,

--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 'use strict'
 
 const {resolve} = require('path')
-const chalk = require('chalk')
-const pkg = require('./package.json')
-const debug = require('debug')(`${pkg.name}:boot`)
+    , chalk = require('chalk')
+    , pkg = require('./package.json')
+    , debug = require('debug')(`${pkg.name}:boot`)
 
-const nameError =
+    , nameError =
 `*******************************************************************
  You need to give your app a proper name.
 
@@ -19,11 +19,11 @@ Please change it in ${__dirname}/package.json
   ~ xoxo, bones
 ********************************************************************`
 
-const reasonableName = /^[a-z0-9\-_]+$/
-// RegExp.text docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
-if (!reasonableName.test(pkg.name)) {
-  console.error(chalk.red(nameError))
-}
+    , reasonableName = /^[a-z0-9\-_]+$/
+
+    // RegExp.test docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
+    , _packageDoesntHaveAName = (name =>
+        reasonableName.test(name) || console.error(chalk.red(nameError)))()
 
 // This will load a secrets file from
 //
@@ -32,8 +32,9 @@ if (!reasonableName.test(pkg.name)) {
 //
 // and add it to the environment.
 // Note that this needs to be in your home directory, not the project's root directory
-const env = Object.create(process.env)
+    , env = Object.create(process.env)
     , secretsFile = resolve(env.HOME, `.${pkg.name}.env`)
+
 try {
   const additionalEnv = require(secretsFile)
   Object.assign(env, additionalEnv)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "test": "mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
     "test-watch": "npm run test -- --watch",
     "seed": "node db/seed.js",
-    "deploy-heroku": "bin/deploy-heroku.sh"
+    "deploy-heroku": "bin/deploy-heroku.sh",
+    "lint": "eslint ."
   },
   "repository": {
     "type": "git",
@@ -76,6 +77,12 @@
     "babel-preset-react": "^6.16.0",
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
+    "eslint": "^3.19.0",
+    "eslint-config-standard": "^10.2.1",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-node": "^4.2.2",
+    "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-standard": "^3.0.1",
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
     "supertest": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test-watch": "npm run test -- --watch --reporter=min",
     "seed": "node db/seed.js",
     "deploy-heroku": "bin/deploy-heroku.sh",
-    "lint": "esw . --ext '.js,.jsx'",
+    "lint": "esw . --ignore-path .gitignore --ext '.js,.jsx'",
     "lint-watch": "npm run lint -- -w"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "description": "A happy little skeleton.",
   "main": "index.js",
+  "engines": {
+    "node": ">= 7.0.0"
+  },
   "scripts": {
     "validate": "check-node-version --node '>= 6.7.0'",
     "setup": "./bin/setup",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "dev": "node dev",
-    "validate": "check-node-version --node '>= 6.7.0'",
+    "validate": "check-node-version --node '>= 7.0.0'",
     "setup": "./bin/setup",
     "prep": "npm run validate && npm run setup",
     "postinstall": "npm run prep",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test-watch": "npm run test -- --watch --reporter=min",
     "seed": "node db/seed.js",
     "deploy-heroku": "bin/deploy-heroku.sh",
-    "lint": "eslint --ext '.js,.jsx' .",
-    "lint-watch": "esw . --ext '.js,.jsx' -w"
+    "lint": "esw . --ext '.js,.jsx'",
+    "lint-watch": "npm run lint -- -w"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">= 7.0.0"
   },
   "scripts": {
+    "dev": "node dev",
     "validate": "check-node-version --node '>= 6.7.0'",
     "setup": "./bin/setup",
     "prep": "npm run validate && npm run setup",
@@ -18,12 +19,12 @@
     "start": "node server/start.js",
     "start-watch": "nodemon server/start.js --watch server --watch db --watch index.js --watch package.json",
     "start-dev": "cross-env NODE_ENV=development npm run start-watch",
-    "dev": "cross-env NODE_ENV=development concurrently --kill-others --prefix \"[{name}]\" --names \"BUILD,SERVE\" -c \"bgBlue.bold.black,bgGreen.bold.black\" \"npm run build-dev\" \"npm run start-dev\"",
-    "test": "mocha --compilers js:babel-register app/**/*.test.js app/**/*.test.jsx db/**/*.test.js server/**/*.test.js",
-    "test-watch": "npm run test -- --watch",
+    "test": "mocha --compilers js:babel-register --watch-extensions js,jsx app/**/*.test.js app/**/*.test.jsx server/**/*.test.js db/**/*.test.js",
+    "test-watch": "npm run test -- --watch --reporter=min",
     "seed": "node db/seed.js",
     "deploy-heroku": "bin/deploy-heroku.sh",
-    "lint": "eslint ."
+    "lint": "eslint --ext '.js,.jsx' .",
+    "lint-watch": "esw . --ext '.js,.jsx' -w"
   },
   "repository": {
     "type": "git",
@@ -75,17 +76,21 @@
   "devDependencies": {
     "babel": "^6.5.2",
     "babel-core": "^6.18.0",
+    "babel-eslint": "^7.2.2",
     "babel-loader": "^6.2.7",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "chai": "^3.5.0",
     "cross-env": "^3.1.4",
+    "dateformat": "^2.0.0",
     "eslint": "^3.19.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-node": "^4.2.2",
     "eslint-plugin-promise": "^3.5.0",
+    "eslint-plugin-react": "^6.10.3",
     "eslint-plugin-standard": "^3.0.1",
+    "eslint-watch": "^3.1.0",
     "mocha": "^3.1.2",
     "nodemon": "^1.11.0",
     "supertest": "^3.0.0",

--- a/server/api.js
+++ b/server/api.js
@@ -1,10 +1,9 @@
 'use strict'
 
-const db = require('APP/db')
 const api = module.exports = require('express').Router()
 
 api
-  .get('/heartbeat', (req, res) => res.send({ok: true,}))
+  .get('/heartbeat', (req, res) => res.send({ok: true}))
   .use('/auth', require('./auth'))
   .use('/users', require('./users'))
 

--- a/server/auth.filters.js
+++ b/server/auth.filters.js
@@ -12,10 +12,10 @@ const selfOnly = action => (req, res, next) => {
   next()
 }
 
-const forbidden = message => (req, res, next) => {
+const forbidden = message => (req, res) => {
   res.status(403).send(message)
 }
 
 // Feel free to add more filters here (suggested: something that keeps out non-admins)
 
-module.exports = {mustBeLoggedIn, selfOnly, forbidden,}
+module.exports = {mustBeLoggedIn, selfOnly, forbidden}

--- a/server/auth.js
+++ b/server/auth.js
@@ -2,8 +2,7 @@ const app = require('APP'), {env} = app
 const debug = require('debug')(`${app.name}:auth`)
 const passport = require('passport')
 
-const User = require('APP/db/models/user')
-const OAuth = require('APP/db/models/oauth')
+const {User, OAuth} = require('APP/db')
 const auth = require('express').Router()
 
 /*************************

--- a/server/auth.js
+++ b/server/auth.js
@@ -6,7 +6,6 @@ const User = require('APP/db/models/user')
 const OAuth = require('APP/db/models/oauth')
 const auth = require('express').Router()
 
-
 /*************************
  * Auth strategies
  *
@@ -96,7 +95,7 @@ passport.deserializeUser(
 )
 
 // require.('passport-local').Strategy => a function we can use as a constructor, that takes in a callback
-passport.use(new (require('passport-local').Strategy) (
+passport.use(new (require('passport-local').Strategy)(
   (email, password, done) => {
     debug('will authenticate user(email: "%s")', email)
     User.findOne({where: {email}})
@@ -122,7 +121,7 @@ passport.use(new (require('passport-local').Strategy) (
 auth.get('/whoami', (req, res) => res.send(req.user))
 
 // POST requests for local login:
-auth.post('/login/local', passport.authenticate('local', { successRedirect: '/', }))
+auth.post('/login/local', passport.authenticate('local', {successRedirect: '/'}))
 
 // GET requests for OAuth login:
 // Register this route as a callback URL with OAuth provider
@@ -134,10 +133,9 @@ auth.get('/login/:strategy', (req, res, next) =>
   })(req, res, next)
 )
 
-auth.post('/logout', (req, res, next) => {
+auth.post('/logout', (req, res) => {
   req.logout()
   res.redirect('/api/auth/whoami')
 })
 
 module.exports = auth
-

--- a/server/auth.js
+++ b/server/auth.js
@@ -126,9 +126,11 @@ auth.post('/login/local', passport.authenticate('local', {successRedirect: '/'})
 // Register this route as a callback URL with OAuth provider
 auth.get('/login/:strategy', (req, res, next) =>
   passport.authenticate(req.params.strategy, {
-    scope: 'email',
+    scope: 'email', // You may want to ask for additional OAuth scopes. These are
+                    // provider specific, and let you access additional data (like
+                    // their friends or email), or perform actions on their behalf.
     successRedirect: '/',
-    // Specify other config here, such as "scope"
+    // Specify other config here
   })(req, res, next)
 )
 

--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -1,7 +1,6 @@
 const request = require('supertest')
 const {expect} = require('chai')
-const db = require('APP/db')
-    , {User} = db
+const db = require('APP/db'), {User} = db
 const app = require('./start')
 
 const alice = {

--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -9,8 +9,8 @@ const alice = {
   password: '12345'
 }
 
+/* global describe it before afterEach beforeEach */
 describe('/api/auth', () => {
-
   before('Await database sync', () => db.didSync)
   afterEach('Clear the tables', () => db.truncate({ cascade: true }))
 
@@ -22,7 +22,6 @@ describe('/api/auth', () => {
   )
 
   describe('POST /login/local (username, password)', () => {
-
     it('succeeds with a valid username and password', () =>
       request(app)
         .post('/api/auth/login/local')
@@ -38,23 +37,17 @@ describe('/api/auth', () => {
         .send({username: alice.username, password: 'wrong'})
         .expect(401)
       )
-
   })
 
   describe('GET /whoami', () => {
-
-    describe('when not logged in', () => {
-
+    describe('when not logged in', () =>
       it('responds with an empty object', () =>
         request(app).get('/api/auth/whoami')
           .expect(200)
           .then(res => expect(res.body).to.eql({}))
-      )
-
-    })
+      ))
 
     describe('when logged in', () => {
-
       // supertest agents persist cookies
       const agent = request.agent(app)
 
@@ -70,15 +63,11 @@ describe('/api/auth', () => {
             email: alice.username
           }))
       )
-
     })
-
   })
 
-  describe('POST /logout', () => {
-
+  describe('POST /logout', () =>
     describe('when logged in', () => {
-
       const agent = request.agent(app)
 
       beforeEach('log in', () => agent
@@ -95,9 +84,6 @@ describe('/api/auth', () => {
             .then(rsp => expect(rsp.body).eql({}))
         )
       )
-
     })
-
-  })
-
+  )
 })

--- a/server/auth.test.js
+++ b/server/auth.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest')
 const {expect} = require('chai')
 const db = require('APP/db')
-const User = require('APP/db/models/user')
+    , {User} = db
 const app = require('./start')
 
 const alice = {

--- a/server/start.js
+++ b/server/start.js
@@ -24,7 +24,7 @@ if (!pkg.isProduction && !pkg.isTesting) {
 }
 
 // Pretty error prints errors all pretty.
-const prettyError = new PrettyError();
+const prettyError = new PrettyError
 
 // Skip events.js and http.js and similar core node files.
 prettyError.skipNodeFiles()
@@ -35,7 +35,7 @@ prettyError.skipPackage('express')
 module.exports = app
   // Session middleware - compared to express-session (which is what's used in the Auther workshop), cookie-session stores sessions in a cookie, rather than some other type of session store.
   // Cookie-session docs: https://www.npmjs.com/package/cookie-session
-  .use(require('cookie-session') ({
+  .use(require('cookie-session')({
     name: 'session',
     keys: [process.env.SESSION_SECRET || 'an insecure secret key'],
   }))
@@ -71,7 +71,7 @@ module.exports = app
   // Error middleware interceptor, delegates to same handler Express uses.
   // https://github.com/expressjs/express/blob/master/lib/application.js#L162
   // https://github.com/pillarjs/finalhandler/blob/master/index.js#L172
-  .use((err, req, res, next) => {
+  .use((err, req, res) => {
     console.error(prettyError.render(err))
     finalHandler(req, res)(err)
   })

--- a/server/users.js
+++ b/server/users.js
@@ -3,18 +3,29 @@
 const db = require('APP/db')
 const User = db.model('users')
 
-const {mustBeLoggedIn, forbidden,} = require('./auth.filters')
+const {mustBeLoggedIn, forbidden} = require('./auth.filters')
 
 module.exports = require('express').Router()
-	.get('/', forbidden('only admins can list users'), (req, res, next) => 
-		User.findAll()
-		.then(users => res.json(users))
-		.catch(next))
-	.post('/', (req, res, next) =>
-		User.create(req.body)
-		.then(user => res.status(201).json(user))
-		.catch(next))
-	.get('/:id', mustBeLoggedIn, (req, res, next) => 
-		User.findById(req.params.id)
-		.then(user => res.json(user))
-		.catch(next))
+  .get('/',
+    // The forbidden middleware will fail *all* requests to list users.
+    // Remove it if you want to allow anyone to list all users on the site.
+    //
+    // If you want to only let admins list all the users, then you'll
+    // have to add a role column to the users table to support
+    // the concept of admin users.
+    forbidden('listing users is not allowed'),
+    (req, res, next) =>
+      User.findAll()
+        .then(users => res.json(users))
+        .catch(next))
+  .post('/',
+    (req, res, next) =>
+      User.create(req.body)
+      .then(user => res.status(201).json(user))
+      .catch(next))
+  .get('/:id',
+    mustBeLoggedIn,
+    (req, res, next) =>
+      User.findById(req.params.id)
+      .then(user => res.json(user))
+      .catch(next))

--- a/server/users.test.js
+++ b/server/users.test.js
@@ -1,32 +1,24 @@
 const request = require('supertest')
-const {expect} = require('chai')
-const db = require('APP/db')
-const User = require('APP/db/models/user')
-const app = require('./start')
+    , {expect} = require('chai')
+    , db = require('APP/db')
+    , app = require('./start')
+
+/* global describe it before afterEach */
 
 describe('/api/users', () => {
-
   before('Await database sync', () => db.didSync)
   afterEach('Clear the tables', () => db.truncate({ cascade: true }))
 
-  describe('GET /:id', () => {
-
-    describe('when not logged in', () => {
-
+  describe('GET /:id', () =>
+    describe('when not logged in', () =>
       it('fails with a 401 (Unauthorized)', () =>
         request(app)
           .get(`/api/users/1`)
           .expect(401)
-      )
+      )))
 
-    })
-
-  })
-
-  describe('POST', () => {
-
+  describe('POST', () =>
     describe('when not logged in', () => {
-
       it('creates a user', () =>
         request(app)
           .post('/api/users')
@@ -34,8 +26,7 @@ describe('/api/users', () => {
             email: 'beth@secrets.org',
             password: '12345'
           })
-          .expect(201)
-      )
+          .expect(201))
 
       it('redirects to the user it just made', () =>
         request(app)
@@ -47,11 +38,6 @@ describe('/api/users', () => {
           .redirects(1)
           .then(res => expect(res.body).to.contain({
             email: 'eve@interloper.com'
-          }))
-      )
-
-    })
-
-  })
-
+          })))
+    }))
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const LiveReloadPlugin = require('webpack-livereload-plugin')
-const devMode = require('.').isDevelopment
+    , devMode = require('.').isDevelopment
 
 /**
  * Fast source maps rebuild quickly during development, but only give a link
@@ -10,7 +10,7 @@ const devMode = require('.').isDevelopment
  * usable stack traces. Set to `true` if you want to speed up development.
  */
 
-const USE_FAST_SOURCE_MAPS = false
+    , USE_FAST_SOURCE_MAPS = false
 
 module.exports = {
   entry: './app/main.jsx',
@@ -19,9 +19,9 @@ module.exports = {
     filename: './public/bundle.js'
   },
   context: __dirname,
-  devtool: devMode && USE_FAST_SOURCE_MAPS ?
-    'cheap-module-eval-source-map' :
-    'source-map',
+  devtool: devMode && USE_FAST_SOURCE_MAPS
+    ? 'cheap-module-eval-source-map'
+    : 'source-map',
   resolve: {
     extensions: ['.js', '.jsx', '.json', '*']
   },
@@ -37,9 +37,7 @@ module.exports = {
       }]
     }]
   },
-  plugins: devMode ? [
-    new LiveReloadPlugin({
-      appendScriptTag: true
-    })
-  ] : []
+  plugins: devMode
+    ? [new LiveReloadPlugin({appendScriptTag: true})]
+    : []
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,11 +19,25 @@ acorn-dynamic-import@^2.0.0:
   dependencies:
     acorn "^4.0.3"
 
+acorn-jsx@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+  dependencies:
+    acorn "^3.0.4"
+
+acorn@^3.0.4:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
+
 acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.11"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.11.tgz#edcda3bd937e7556410d42ed5860f67399c794c0"
 
-ajv-keywords@^1.1.1:
+acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
 
@@ -41,6 +55,10 @@ align-text@^0.1.1, align-text@^0.1.3:
     kind-of "^3.0.2"
     longest "^1.0.1"
     repeat-string "^1.5.2"
+
+ansi-escapes@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
 ansi-regex@^0.2.0, ansi-regex@^0.2.1:
   version "0.2.1"
@@ -76,6 +94,12 @@ are-we-there-yet@~1.1.2:
     delegates "^1.0.0"
     readable-stream "^2.0.0 || ^1.1.13"
 
+argparse@^1.0.7:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
+  dependencies:
+    sprintf-js "~1.0.2"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -89,6 +113,16 @@ arr-flatten@^1.0.1:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  dependencies:
+    array-uniq "^1.0.1"
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
 array-unique@^0.2.1:
   version "0.2.1"
@@ -164,7 +198,7 @@ axios@^0.15.2:
   dependencies:
     follow-redirects "1.0.0"
 
-babel-code-frame@^6.20.0:
+babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
   dependencies:
@@ -958,7 +992,7 @@ buffer@^4.3.0:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
-builtin-modules@^1.0.0:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -973,6 +1007,16 @@ bytes@2.2.0:
 bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
+
+caller-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
+  dependencies:
+    callsites "^0.2.0"
+
+callsites@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -1078,6 +1122,20 @@ cipher-base@^1.0.0, cipher-base@^1.0.1:
   dependencies:
     inherits "^2.0.1"
 
+circular-json@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
+
+cli-cursor@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+  dependencies:
+    restore-cursor "^1.0.1"
+
+cli-width@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1134,7 +1192,7 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7:
+concat-stream@^1.4.7, concat-stream@^1.5.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
   dependencies:
@@ -1181,6 +1239,10 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
 constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 content-disposition@0.5.1:
   version "0.5.1"
@@ -1303,6 +1365,12 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+d@1:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
+  dependencies:
+    es5-ext "^0.10.9"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1323,13 +1391,13 @@ debug@2.2.0, debug@~2.2.0:
   dependencies:
     ms "0.7.1"
 
-debug@2.3.2, debug@^2.1.1, debug@^2.2.0:
+debug@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.2.tgz#94cb466ef7d6d2c7e5245cdd6e4104f2d0d70d30"
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1:
+debug@2.6.1, debug@^2.1.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -1353,12 +1421,28 @@ deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
 
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+del@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
+  dependencies:
+    globby "^5.0.0"
+    is-path-cwd "^1.0.0"
+    is-path-in-cwd "^1.0.0"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+    rimraf "^2.2.8"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1400,6 +1484,20 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.0.0.tgz#c73d8d2909d22291e1a007a395804da8b665fe63"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
 
 dom-converter@~0.1:
   version "0.1.4"
@@ -1570,17 +1668,202 @@ es-to-primitive@^1.1.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
 
+es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
+  version "0.10.15"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.15.tgz#c330a5934c1ee21284a7c081a86e5fd937c91ea6"
+  dependencies:
+    es6-iterator "2"
+    es6-symbol "~3.1"
+
+es6-iterator@2, es6-iterator@^2.0.1, es6-iterator@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.1.tgz#8e319c9f0453bf575d374940a655920e59ca5512"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-symbol "^3.1"
+
+es6-map@^0.1.3:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-set "~0.1.5"
+    es6-symbol "~3.1.1"
+    event-emitter "~0.3.5"
+
 es6-promise@^3.0.2:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.3.1.tgz#a08cdde84ccdbf34d027a1451bc91d4bcd28a613"
+
+es6-set@~0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+    es6-iterator "~2.0.1"
+    es6-symbol "3.1.1"
+    event-emitter "~0.3.5"
+
+es6-symbol@3.1.1, es6-symbol@^3.1, es6-symbol@^3.1.1, es6-symbol@~3.1, es6-symbol@~3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
+
+es6-weak-map@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
+  dependencies:
+    d "1"
+    es5-ext "^0.10.14"
+    es6-iterator "^2.0.1"
+    es6-symbol "^3.1.1"
 
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
+escope@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+  dependencies:
+    es6-map "^0.1.3"
+    es6-weak-map "^2.0.1"
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-config-standard@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.2.0"
+    eslint-module-utils "^2.0.0"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    pkg-up "^1.0.0"
+
+eslint-plugin-node@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz#82959ca9aed79fcbd28bb1b188d05cac04fb3363"
+  dependencies:
+    ignore "^3.0.11"
+    minimatch "^3.0.2"
+    object-assign "^4.0.1"
+    resolve "^1.1.7"
+    semver "5.3.0"
+
+eslint-plugin-promise@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
+
+eslint-plugin-standard@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
+
+eslint@^3.19.0:
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
+espree@^3.4.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.1.tgz#28a83ab4aaed71ed8fe0f5efe61b76a05c13c4d2"
+  dependencies:
+    acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
+
+esprima@^3.1.1:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
+esquery@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.0.tgz#cfba8b57d7fba93f17298a8a006a04cda13d80fa"
+  dependencies:
+    estraverse "^4.0.0"
+
+esrecurse@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.1.0.tgz#4713b6536adf7f2ac4f327d559e7756bff648220"
+  dependencies:
+    estraverse "~4.1.0"
+    object-assign "^4.0.1"
+
+estraverse@^4.0.0, estraverse@^4.1.1, estraverse@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
+
+estraverse@~4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
 esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.2"
@@ -1589,6 +1872,13 @@ esutils@^2.0.0, esutils@^2.0.2:
 etag@~1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.7.0.tgz#03d30b5f67dd6e632d2945d30d6652731a34d5d8"
+
+event-emitter@~0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
+  dependencies:
+    d "1"
+    es5-ext "~0.10.14"
 
 event-stream@~3.3.0:
   version "3.3.4"
@@ -1611,6 +1901,10 @@ evp_bytestokey@^1.0.0:
   resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz#497b66ad9fef65cd7c08a6180824ba1476b66e53"
   dependencies:
     create-hash "^1.1.1"
+
+exit-hook@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -1669,6 +1963,10 @@ extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
+fast-levenshtein@~2.0.4:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
 faye-websocket@~0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.10.0.tgz#4e492f8d04dfb6f89003507f6edbf2d501e7c6f4"
@@ -1686,6 +1984,20 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+figures@^1.3.5:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    object-assign "^4.1.0"
+
+file-entry-cache@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-2.0.0.tgz#c392990c3e684783d838b8c84a45d8a048458361"
+  dependencies:
+    flat-cache "^1.2.1"
+    object-assign "^4.0.1"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -1741,6 +2053,15 @@ find-up@^1.0.0:
   dependencies:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
+
+flat-cache@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
+  dependencies:
+    circular-json "^0.3.1"
+    del "^2.0.2"
+    graceful-fs "^4.1.2"
+    write "^0.2.1"
 
 follow-redirects@1.0.0:
   version "1.0.0"
@@ -1887,7 +2208,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5, glob@^7.0.5:
+glob@7.0.5, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
   dependencies:
@@ -1898,9 +2219,20 @@ glob@7.0.5, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
+
+globby@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-5.0.0.tgz#ebd84667ca0dbb330b99bcfc68eac2bc54370e0d"
+  dependencies:
+    array-union "^1.0.1"
+    arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 got@^3.2.0:
   version "3.3.1"
@@ -2080,6 +2412,10 @@ ignore-by-default@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ignore-by-default/-/ignore-by-default-1.0.1.tgz#48ca6d72f6c6a3af00a9ad4ae6876be3889e2b09"
 
+ignore@^3.0.11, ignore@^3.2.0:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.7.tgz#4810ca5f1d8eca5595213a34b94f2eb4ed926bbd"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -2114,6 +2450,24 @@ inherits@2.0.1:
 ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    ansi-regex "^2.0.0"
+    chalk "^1.0.0"
+    cli-cursor "^1.0.1"
+    cli-width "^2.0.0"
+    figures "^1.3.5"
+    lodash "^4.3.0"
+    readline2 "^1.0.1"
+    run-async "^0.1.0"
+    rx-lite "^3.1.2"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
 
 interpret@^1.0.0:
   version "1.0.1"
@@ -2191,13 +2545,17 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
 
-is-my-json-valid@^2.12.4:
+is-my-json-valid@^2.10.0, is-my-json-valid@^2.12.4:
   version "2.15.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz#936edda3ca3c211fd98f3b2d3e08da43f7b2915b"
   dependencies:
@@ -2215,6 +2573,22 @@ is-number@^2.0.2, is-number@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
   dependencies:
     kind-of "^3.0.2"
+
+is-path-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
+
+is-path-in-cwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz#6477582b8214d602346094567003be8a9eac04dc"
+  dependencies:
+    is-path-inside "^1.0.0"
+
+is-path-inside@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-1.0.0.tgz#fc06e5a1683fbda13de667aff717bbc10a48f37f"
+  dependencies:
+    path-is-inside "^1.0.1"
 
 is-plain-obj@^1.0.0:
   version "1.1.0"
@@ -2249,6 +2623,12 @@ is-regex@^1.0.3:
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
+
+is-resolvable@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
+  dependencies:
+    tryit "^1.0.1"
 
 is-stream@^1.0.0, is-stream@^1.0.1:
   version "1.1.0"
@@ -2313,6 +2693,13 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-yaml@^3.5.1:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
 jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
@@ -2333,7 +2720,7 @@ json-schema@0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
 
-json-stable-stringify@^1.0.1:
+json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
   dependencies:
@@ -2392,6 +2779,13 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 livereload-js@^2.2.0:
   version "2.2.2"
@@ -2475,6 +2869,10 @@ lodash.bind@^4.1.4:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
 
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
 lodash.create@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.create/-/lodash.create-3.1.1.tgz#d7f2849f0dbda7e04682bb8cd72ab022461debe7"
@@ -2554,7 +2952,7 @@ lodash@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.5.1:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2653,7 +3051,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
 
-minimatch@^3.0.0, minimatch@^3.0.2:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -2707,9 +3105,17 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+mute-stream@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+
 nan@^2.3.0:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.3.5.tgz#822a0dc266290ce4cd3a12282ca3e7e364668a08"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -2912,6 +3318,21 @@ once@~1.3.0, once@~1.3.3:
   dependencies:
     wrappy "1"
 
+onetime@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+
+optionator@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.4"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    wordwrap "~1.0.0"
+
 os-browserify@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.2.1.tgz#63fc4ccee5d2d7763d26bbf8601078e6c2e0044f"
@@ -3060,6 +3481,14 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
+path-is-inside@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -3141,6 +3570,20 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
+  dependencies:
+    find-up "^1.0.0"
+
+pluralize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
 prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
@@ -3167,6 +3610,10 @@ process-nextick-args@~1.0.6:
 process@^0.11.0:
   version "0.11.9"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.9.tgz#7bd5ad21aa6253e7da8682264f1e11d11c0318c1"
+
+progress@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
 promise@^7.1.1:
   version "7.1.1"
@@ -3394,6 +3841,20 @@ readdirp@^2.0.0:
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
 
+readline2@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
+  dependencies:
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
+    mute-stream "0.0.5"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  dependencies:
+    resolve "^1.1.6"
+
 redux-devtools-extension@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.0.tgz#c8300d72630c00999302526204d47c360cc0637f"
@@ -3527,6 +3988,30 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-uncached@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
+  dependencies:
+    caller-path "^0.1.0"
+    resolve-from "^1.0.0"
+
+resolve-from@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve@^1.1.6, resolve@^1.1.7:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.2.tgz#1f0442c9e0cbb8136e87b9305f932f46c7f28235"
+  dependencies:
+    path-parse "^1.0.5"
+
+restore-cursor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+  dependencies:
+    exit-hook "^1.0.0"
+    onetime "^1.0.0"
+
 retry-as-promised@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-2.2.0.tgz#b0463d7fd3cf5b2fed64500ab6e8b8a49c5b8e6c"
@@ -3541,7 +4026,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@~2.5.1, rimraf@~2.5.4:
+rimraf@2, rimraf@^2.2.8, rimraf@~2.5.1, rimraf@~2.5.4:
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.5.4.tgz#96800093cbf1a0c86bd95b4625467535c29dfa04"
   dependencies:
@@ -3551,9 +4036,19 @@ ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
 
+run-async@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+  dependencies:
+    once "^1.3.0"
+
 run-parallel@^1.1.4:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.6.tgz#29003c9a2163e01e2d2dfc90575f2c6c1d61a039"
+
+rx-lite@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
 rx@2.3.24:
   version "2.3.24"
@@ -3569,7 +4064,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@~5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.0.1, semver@^5.0.3, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -3647,6 +4142,14 @@ sha.js@^2.3.6:
   dependencies:
     inherits "^2.0.1"
 
+shelljs@^0.7.5:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.7.tgz#b2f5c77ef97148f4b4f6e22682e10bba8667cff1"
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
 shimmer@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shimmer/-/shimmer-1.1.0.tgz#97d7377137ffbbab425522e429fe0aa89a488b35"
@@ -3671,6 +4174,10 @@ sinon@^1.17.6:
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+
+slice-ansi@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
 
 slide@^1.1.5:
   version "1.1.6"
@@ -3731,6 +4238,10 @@ split@^1.0.0:
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.0.tgz#c4395ce683abcd254bc28fe1dabb6e5c27dcffae"
   dependencies:
     through "2"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
 sshpk@^1.7.0:
   version "1.10.1"
@@ -3796,6 +4307,13 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
 string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -3829,9 +4347,17 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+
 strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 superagent@^3.0.0:
   version "3.5.0"
@@ -3879,6 +4405,17 @@ symbol-observable@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
+table@^3.7.8:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+  dependencies:
+    ajv "^4.7.0"
+    ajv-keywords "^1.0.0"
+    chalk "^1.1.1"
+    lodash "^4.0.0"
+    slice-ansi "0.0.4"
+    string-width "^2.0.0"
+
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.6.tgz#206be8e188860b514425375e6f1ae89bfb01fd8d"
@@ -3914,7 +4451,11 @@ terraformer@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.7.tgz#d8a19a56fbf25966ea062d21f515b93589702d69"
 
-through@2, through@~2.3, through@~2.3.1:
+text-table@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
+
+through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3971,6 +4512,10 @@ tree-kill@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.1.0.tgz#c963dcf03722892ec59cba569e940b71954d1729"
 
+tryit@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
+
 tty-browserify@0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/tty-browserify/-/tty-browserify-0.0.0.tgz#a157ba402da24e9bf957f9aa69d524eed42901a6"
@@ -3982,6 +4527,12 @@ tunnel-agent@~0.4.1:
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-detect@0.1.1:
   version "0.1.1"
@@ -4053,6 +4604,12 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+user-home@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
+  dependencies:
+    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4213,6 +4770,10 @@ wordwrap@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-0.0.2.tgz#b79669bb42ecb409f83d583cad52ca17eaa1643f"
 
+wordwrap@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -4231,6 +4792,12 @@ write-file-atomic@^1.1.2:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     slide "^1.1.5"
+
+write@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/write/-/write-0.2.1.tgz#5fc03828e264cea3fe91455476f7a3c566cb0757"
+  dependencies:
+    mkdirp "^0.5.1"
 
 xdg-basedir@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -128,6 +128,13 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
+array.prototype.find@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -206,6 +213,14 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
+babel-code-frame@^6.22.0:
+  version "6.22.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
+  dependencies:
+    chalk "^1.1.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-core@^6.18.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.21.0.tgz#75525480c21c803f826ef3867d22c19f080a3724"
@@ -229,6 +244,15 @@ babel-core@^6.18.0:
     private "^0.1.6"
     slash "^1.0.0"
     source-map "^0.5.0"
+
+babel-eslint@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.2.tgz#0da2cbe6554fd0fb069f19674f2db2f9c59270ff"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.16.1"
 
 babel-generator@^6.21.0:
   version "6.21.0"
@@ -377,6 +401,12 @@ babel-loader@^6.2.7:
     loader-utils "^0.2.11"
     mkdirp "^0.5.1"
     object-assign "^4.0.1"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
 
 babel-messages@^6.8.0:
   version "6.8.0"
@@ -698,6 +728,14 @@ babel-plugin-transform-strict-mode@^6.18.0:
     babel-runtime "^6.0.0"
     babel-types "^6.18.0"
 
+babel-polyfill@^6.20.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-es2015@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.18.0.tgz#b8c70df84ec948c43dcf2bf770e988eb7da88312"
@@ -770,9 +808,16 @@ babel-register@^6.18.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.20.0, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
@@ -801,11 +846,34 @@ babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-traverse@^6.20.0, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-traverse@^6.23.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
 babel-types@^6.13.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.21.0, babel-types@^6.8.0, babel-types@^6.9.0:
   version "6.21.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.21.0.tgz#314b92168891ef6d3806b7f7a917fdf87c11a4b2"
   dependencies:
     babel-runtime "^6.20.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babel-types@^6.23.0, babel-types@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
+  dependencies:
+    babel-runtime "^6.22.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
@@ -817,6 +885,10 @@ babel@^6.5.2:
 babylon@^6.11.0:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.14.1.tgz#956275fab72753ad9b3435d7afe58f8bf0a29815"
+
+babylon@^6.15.0, babylon@^6.16.1:
+  version "6.16.1"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.16.1.tgz#30c5a22f481978a9e7f8cdfdf496b11d94b404d3"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -850,7 +922,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.3.4, bluebird@^3.4.6:
+bluebird@^3.3.4, bluebird@^3.4.6, bluebird@^3.4.7:
   version "3.4.7"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
 
@@ -1385,6 +1457,10 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
+dateformat@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.0.0.tgz#2743e3abb5c3fc2462e527dca445e04e9f4dee17"
+
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -1400,6 +1476,12 @@ debug@2.3.2:
 debug@2.6.1, debug@^2.1.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  dependencies:
+    ms "0.7.2"
+
+debug@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
@@ -1485,7 +1567,7 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-doctrine@1.5.0:
+doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
@@ -1660,6 +1742,15 @@ es-abstract@^1.6.1:
     is-callable "^1.1.3"
     is-regex "^1.0.3"
 
+es-abstract@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
+
 es-to-primitive@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
@@ -1789,9 +1880,35 @@ eslint-plugin-promise@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
 
+eslint-plugin-react@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
+  dependencies:
+    array.prototype.find "^2.0.1"
+    doctrine "^1.2.2"
+    has "^1.0.1"
+    jsx-ast-utils "^1.3.4"
+    object.assign "^4.0.4"
+
 eslint-plugin-standard@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
+
+eslint-watch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-watch/-/eslint-watch-3.1.0.tgz#8a98006f7d7c583262f6fd78613f0ff406044930"
+  dependencies:
+    babel-polyfill "^6.20.0"
+    bluebird "^3.4.7"
+    chalk "^1.1.3"
+    chokidar "^1.4.3"
+    debug "^2.6.3"
+    keypress "^0.2.1"
+    lodash "^4.17.4"
+    optionator "^0.8.2"
+    source-map-support "^0.4.14"
+    text-table "^0.2.0"
+    unicons "0.0.3"
 
 eslint@^3.19.0:
   version "3.19.0"
@@ -2693,6 +2810,10 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-tokens@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
+
 js-yaml@^3.5.1:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
@@ -2754,9 +2875,19 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+jsx-ast-utils@^1.3.4:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
+  dependencies:
+    object-assign "^4.1.0"
+
 keygrip@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/keygrip/-/keygrip-1.0.1.tgz#b02fa4816eef21a8c4b35ca9e52921ffc89a30e9"
+
+keypress@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
 
 kind-of@^3.0.2:
   version "3.1.0"
@@ -2952,7 +3083,7 @@ lodash@4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.12.0.tgz#2bd6dc46a040f59e686c972ed21d93dc59053258"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4199,13 +4330,13 @@ source-list-map@~0.1.7:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.8.tgz#c550b2ab5427f6b3f21f5afead88c4f5587b2106"
 
-source-map-support@^0.4.2:
-  version "0.4.8"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.8.tgz#4871918d8a3af07289182e974e32844327b2e98b"
+source-map-support@^0.4.14, source-map-support@^0.4.2:
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.14.tgz#9d4463772598b86271b4f523f6c1f4e02a7d6aef"
   dependencies:
-    source-map "^0.5.3"
+    source-map "^0.5.6"
 
-source-map@^0.5.0, source-map@^0.5.3, source-map@~0.5.1, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -4451,7 +4582,7 @@ terraformer@~1.0.5:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/terraformer/-/terraformer-1.0.7.tgz#d8a19a56fbf25966ea062d21f515b93589702d69"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -4581,6 +4712,10 @@ uid2@0.0.x:
 undefsafe@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-0.0.3.tgz#ecca3a03e56b9af17385baac812ac83b994a962f"
+
+unicons@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/unicons/-/unicons-0.0.3.tgz#6e6a7a1a6eaebb01ca3d8b12ad9687279eaba524"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Remove the cycle in how we define Sequelize models. It creates subtly nondeterministic behavior (which is what my momma warned me about, but I did it anyway, and now we must clean it up.).

Anyway, we're back to injecting the database. This happens right after database initialization, and we now assign all the models to the db object itself.

That means that `require`ing model files directly is out, and this is in:

```javascript
const {User, Product, Item} = require('APP/db')
```

Which I actually quite like.

Another consequence is that associations are now defined in the model files, which may export an `associations` function which will receive the args `(self: Model, others: {[name]: Model})`. On the whole, models now look like this:

```javascript
const {STRING, INTEGER} = require('sequelize')
 
module.exports = db => db.define('items', {
  name: STRING,
  cents: INTEGER,
})

module.exports.associations = (Item, {Review}) => {
  Item.hasMany(Review)
}
```