### PR TITLE
User defaultScope

### DIFF
--- a/db/models/user.js
+++ b/db/models/user.js
@@ -23,6 +23,9 @@ module.exports = db => db.define('users', {
     beforeCreate: setEmailAndPassword,
     beforeUpdate: setEmailAndPassword,
   },
+  defaultScope: {
+    attributes: {exclude: ['password_digest']}
+  },
   instanceMethods: {
     // This method is a Promisified bcrypt.compare
     authenticate(plaintext) {

--- a/server/auth.js
+++ b/server/auth.js
@@ -97,7 +97,10 @@ passport.deserializeUser(
 passport.use(new (require('passport-local').Strategy)(
   (email, password, done) => {
     debug('will authenticate user(email: "%s")', email)
-    User.findOne({where: {email}})
+    User.findOne({
+      where: {email}, 
+      attributes: {include: ['password_digest']}
+    })
       .then(user => {
         if (!user) {
           debug('authenticate user(email: "%s") did fail: no such user', email)


### PR DESCRIPTION
added default scope to exclude password_digest for user queries. I thought this would be a nice example for them after the DADA lecture of how to do something similar. Obviously not necessary since it is hashed, but might be good for a getAllUsers type scenario