### PR TITLE
Replaces Object.create with Object.assign for creating env

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ if (!reasonableName.test(pkg.name)) {
 //
 // and add it to the environment.
 // Note that this needs to be in your home directory, not the project's root directory
-const env = Object.create(process.env)
+const env = Object.assign({}, process.env)
     , secretsFile = resolve(require('homedir')(), `.${pkg.name}.env`)
 
 try {


### PR DESCRIPTION
We had a team working on grace-shopper which ran into a bug in which `process.env.HOME` was undefined. It appears that reassigning `process.env = env` on index.js line 41 puts what had been directly on the object to now be accessible through inheritance. In the taskEnvironment in dev.js line 19, we build up the spawned task's env through the iterable properties on process.env, which no longer includes HOME. 

Is there a reason for hiding the rest of the process.env from the process.env of the spawned tasks?