### PR TITLE
fix(server/start): error middleware missing param

### DIFF
--- a/server/start.js
+++ b/server/start.js
@@ -71,7 +71,7 @@ module.exports = app
   // Error middleware interceptor, delegates to same handler Express uses.
   // https://github.com/expressjs/express/blob/master/lib/application.js#L162
   // https://github.com/pillarjs/finalhandler/blob/master/index.js#L172
-  .use((err, req, res) => {
+  .use((err, req, res, next) => {
     console.error(prettyError.render(err))
     finalHandler(req, res)(err)
   })


### PR DESCRIPTION
@khumphrey noticed today that we had a regression bug — the fourth parameter of our error handling middleware was recently deleted. Without that param, this function no longer serves as an error handler, instead becoming normal middleware. This PR puts it back the way it's meant to be.