### PR TITLE
Fix eslint: move `ecmaFeatures` into `parserOptions`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,10 +4,10 @@ module.exports = {
   parser: "babel-eslint",
   parserOptions: {
     sourceType: "module",
-    ecmaVersion: 8
-  },
-  ecmaFeatures: {
-    jsx: true,
+    ecmaVersion: 8,
+    ecmaFeatures: {
+      jsx: true,
+    },
   },
   plugins: ['react'],
   rules: {


### PR DESCRIPTION
This fixes a typo-kind-of-thing (presumably). Some 1706 FSA NY Grace Shopper teams were having issues because of this.